### PR TITLE
Adds and configures MySQL for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,36 @@ jobs:
         parameters:
             ruby_version:
                 type: string
-                default: 2.5.3
+                default: '2.5.3'
             bundler_version:
                 type: string
-                default: 2.0.1
-        executor:
-            name: samvera/ruby_fcrepo_solr_redis
-            ruby_version: << parameters.ruby_version >>
+                default: '2.0.1'
+            solr_port:
+                type: string
+                default: '8985'
+            redis_version:
+                type: string
+                default: '4'
+            mysql_version:
+                type: string
+                default: '5.7.22'
+        environment:
+            BUNDLE_PATH: vendor/bundle
+            BUNDLE_JOBS: 4
+            BUNDLE_RETRY: 3
+            RAILS_ENV: test
+            RACK_ENV: test
+            SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+            DATABASE_NAME: circle_test
+            DATABASE_HOST: 127.0.0.1
+            DATABASE_PORT: 3306
+            DATABASE_USERNAME: root
+        docker:
+            - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+            - image: solr:7-alpine
+              command: bin/solr -cloud -noprompt -f -p <<parameters.solr_port>>
+            - image: circleci/redis:<<parameters.redis_version>>
+            - image: circleci/mysql:<<parameters.mysql_version>>
         working_directory: ~/project
         parallelism: 4
         steps:
@@ -48,6 +71,11 @@ jobs:
                     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
                     chmod +x ./cc-test-reporter
                     ./cc-test-reporter before-build
+
+            # Dockerize is installed in CircleCI docker images by default.
+            - run:
+                name: Wait for MySQL, if necessary.
+                command: dockerize -wait tcp://${DATABASE_HOST}:${DATABASE_PORT} -timeout 1m
 
             - samvera/parallel_rspec
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,30 +1,28 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: mysql2
+  encoding: utf8mb4
   timeout: 5000
+  database: <%= ENV.fetch('DATABASE_NAME') %>
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  port: <%= ENV.fetch('DATABASE_PORT', '3306') %>
+  username: <%= ENV.fetch('DATABASE_USERNAME') %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  pool: <%= ENV['DATABASE_POOL'] || ENV['RAILS_MAX_THREADS'] || 5 %>
 
 development:
-  <<: *default
+  adapter: sqlite3
+  timeout: 5000
   database: db/development.sqlite3
+  pool: <%= ENV['DATABASE_POOL'] || ENV['RAILS_MAX_THREADS'] || 5 %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  # If host is 'localhost', MySQL will attempt to use a socket to talk to the DB, but if it is '127.0.0.1',
+  # it will use TCP. While a socket may be a preferable default, it will not work for CI.
+  host: <%= ENV.fetch('DATABASE_HOST', '127.0.0.1') %>
 
 production:
   <<: *default
-  adapter: 'mysql2'
-  database: <%= ENV['DATABASE_NAME'] %> 
-  pool: <%= ENV['DATABASE_POOL'] || 5 %>
-  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
-  username: <%= ENV['DATABASE_USERNAME']  %>
-  password: <%= ENV['DATABASE_PASSWORD'] %>


### PR DESCRIPTION
As a consequence, we can no longer use the Samvera Orb's executor. This also means no more Fedora.