### PR TITLE
Add a sample dotenv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Discovery application for Emory's Cor repository.
 1. Launch a rails server: `rails server`
 1. You should now be able to go to `http://localhost:3000` and see the application
 
+## Running in production
+
+1. The `IIIF_MANIFEST_URL` environment variable needs to be set. This URL is the base
+URL for the Hyrax instance that serves the Work's IIIF manifest. An example:
+`https://curate-qa.curationexperts.com/concern/curate_generic_works/`.
+
 ## Loading sample data
 
 In order to have a local solr instance with data in it, run this rake task:

--- a/config/initializers/iiif_url.rb
+++ b/config/initializers/iiif_url.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Rails.application.config.iiif_url = ENV['IIIF_URL'] || ''
+Rails.application.config.iiif_url = ENV['IIIF_MANIFEST_URL'] || ''

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -1,5 +1,15 @@
-PROJECT_NAME=
+# Varibles used in database.yml:
+DATABASE_NAME=lux_production
+DATABASE_USERNAME=lux
+DATABASE_PASSWORD=lux
+DATABASE_POOL=25
+RAILS_MAX_THREADS=5
 
-DATABASE_NAME=
-DATABASE_USERNAME=
-DATABASE_PASSWORD=
+# Base URL for the Hyrax instance that serves IIIF manifests
+#
+# An example:
+# https://tenejo.curationexperts.com/concern/works/9k41zd48h/manifest
+# The base url will be: https://tenejo.curationexperts.com/concern/works/
+# The string after /works/ is the ID for the work
+IIIF_MANIFEST_URL=https://curate-qa.curationexperts.com/concern/curate_generic_works/
+SOLR_URL=http://localhost:8983/solr/dlp-lux


### PR DESCRIPTION
This includes a dotenv sample file with
vars that are used in the database config
file and an example for the IIIF url.

The README is also updates to include info
about needing to set the IIIF url.

Connected to #61