### PR TITLE
Do not build cd branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,10 @@ workflows:
         jobs:
             - build:
                 name: ruby2-5-3
+                filters:
+                  branches:
+                    ignore:
+                      - /cd-.*/
             - coverage:
                 name: codeclimate
                 requires:


### PR DESCRIPTION
Some branches will exist only for a few minutes, because they belong to
our continuous deploy system. Do not waste our circleci resources on
building them, and do not clutter our circleci interface with them. Just
ignore them.

Connected to https://github.com/emory-libraries/dlp-lux/issues/30