### PR TITLE
Reports different environments to Honeybadger

### DIFF
--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 set :stage, :ARCH
+set :honeybadger_env, "Lux-Arch"
 ec2_role %i[web app db],
          user: 'deploy',
          ssh_options: {

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 set :stage, :PROD
+set :honeybadger_env, "Lux-Prod"
 ec2_role %i[web app db],
          user: 'deploy',
          ssh_options: {

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 set :stage, :TEST
+set :honeybadger_env, "Lux-Test"
 ec2_role %i[web app db],
          user: 'deploy',
          ssh_options: {


### PR DESCRIPTION
This allows us to not only differentiate between Curate and Lux, but the different deployment envs for each.