### PR TITLE
Metadata added to show page, start facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,7 +22,7 @@ class CatalogController < ApplicationController
       mm: '100%',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim',
-      fq: '(((has_model_ssim:CurateGenericWork) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery)))'
+      fq: '(((has_model_ssim:CurateGenericWork) OR (has_model_ssim:Collection)) AND (visibility_ssi:open))'
       ### we want to only return works where visibility_ssi == open (not restricted)
     }
 
@@ -86,7 +86,7 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    # config.add_facet_field 'format', label: 'Format'
+    #config.add_facet_field 'format', label: 'Format'
     #config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     #config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     #config.add_facet_field 'language_ssim', label: 'Language', limit: true
@@ -113,7 +113,27 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    # config.add_show_field 'title_tesim', label: 'Title'
+    # For "About this item" section of show page
+    config.add_show_field 'creator_tesim', label: 'Creator'
+    config.add_show_field 'contributors_tesim', label: 'Contributor'
+    config.add_show_field 'date_created_tesim', label: 'Date Created'
+    config.add_show_field 'date_issued_tesim', label: 'Date Issued'
+    config.add_show_field 'uniform_title_tesim', label: 'Uniform Title'
+    config.add_show_field 'series_title_tesim', label: 'Series Title'
+    config.add_show_field 'parent_title_tesim', label: 'Title of Parent Work'
+    config.add_show_field 'abstract_tesim', label: 'Description/Abstract'
+    config.add_show_field 'primary_language_tesim', label: 'Primary Language'
+    config.add_show_field 'human_readable_content_type_tesim', label: 'Content Type'
+    config.add_show_field 'content_genres_tesim', label: 'Genre'
+    config.add_show_field 'geographic_unit_tesim', label: 'Geographic Level for Dataset'
+    config.add_show_field 'data_collection_dates_tesim', label: 'Data Collection Dates'
+    config.add_show_field 'notes_tesim', label: 'Note'
+    # For "Keywords" section of show page
+    config.add_show_field 'subject_time_periods_tesim', label: 'Subject - Time Periods'
+    config.add_show_field 'subject_topics_tesim', label: 'Subject - Topics'
+    config.add_show_field 'subject_names_tesim', label: 'Subject - Names'
+    config.add_show_field 'subject_geo_tesim', label: 'Subject - Geographic Locations'
+    config.add_show_field 'keywords_tesim', label: 'Keywords'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -86,7 +86,18 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    #config.add_facet_field 'format', label: 'Format'
+    config.add_facet_field 'creator_tesim', label: 'Creators'
+    config.add_facet_field 'human_readable_content_type_tesim', label: 'Content Type'
+    config.add_facet_field 'date_created_tesim', label: 'Date Created'
+    config.add_facet_field 'date_issued_tesim', label: 'Date Issued'
+    config.add_facet_field 'content_genres_tesim', label: 'Genre'
+    config.add_facet_field 'holding_repository_tesim', label: 'Library'
+    config.add_facet_field 'primary_language_tesim', label: 'Primary Language'
+    config.add_facet_field 'rights_statement_tesim', label: 'Rights Statement - Controlled'
+    config.add_facet_field 'subject_geo_tesim', label: 'Subject - Geographic Locations'
+    config.add_facet_field 'subject_names_tesim', label: 'Subject - Names'
+    config.add_facet_field 'subject_topics_tesim', label: 'Subject - Topics'
+
     #config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     #config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     #config.add_facet_field 'language_ssim', label: 'Language', limit: true

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,0 +1,8 @@
+<% doc_presenter = show_presenter(document) %>
+<%# default partial to display solr document fields in catalog show view -%>
+<dl class="row dl-invert document-metadata">
+  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
+    <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
+    <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+  <% end -%>
+</dl>

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -39,4 +39,16 @@ RSpec.feature "View Search Results", type: :system, js: true do
     expect(page).to have_xpath("//img[@alt='Thumbnail image']")
     expect(page).to have_xpath("//img[@src='http://obviously_fake_url.com/downloads/825x69p8dh-cor?file=thumbnail']")
   end
+
+  xit 'shows available facets on the page' do
+    visit "/"
+    fill_in 'q', with: 'The Title of my Work'
+    click_on 'Search'
+    click_on 'Creators'
+    expect(page).to have_selector('#facet-creator_tesim')
+    click_on 'Content Type'
+    expect(page).to have_selector('#facet-human_readable_content_type_tesim')
+    click_on 'Date Created'
+    expect(page).to have_selector('#facet-date_created_tesim')
+  end
 end

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -14,14 +14,61 @@ RSpec.feature "View a Work" do
   let(:work_attributes) do
     {
       id: id,
-      has_model_ssim: ['Work'],
+      has_model_ssim: ['CurateGenericWork'],
       title_tesim: ['The Title of my Work'],
-      description_tesim: ['Description 1', 'Description 2']
+      creator_tesim: ['Smith, Somebody'],
+      contributors_tesim: ['Contributor, Jack'],
+      date_created_tesim: ['1776', 'XXXX', '192?', '1973?'],
+      date_issued_tesim: ['1652'],
+      uniform_title_tesim: ['This is a uniform title'],
+      series_title_tesim: ['This is a series title'],
+      parent_title_tesim: ['This is a parent title'],
+      abstract_tesim: ['Description or abstract of work'],
+      primary_language_tesim: ['English'],
+      content_type_tesim: ['http://id.loc.gov/vocabulary/resourceTypes/txt'],
+      content_genres_tesim: ['Painting'],
+      human_readable_content_type_tesim: ['Text'],
+      geographic_unit_tesim: ['State'],
+      data_collection_dates_tesim: ['1985'],
+      visibility_ssi: ['open'],
+      notes_tesim: ['notes about a thing'],
+      subject_time_periods_tesim: ['Edo (African)'],
+      subject_topics_tesim: ['Cheese'],
+      subject_names_tesim: ['Qāsimlū, Mujtabá'],
+      subject_geo_tesim: ['New Jersey'],
+      keywords_tesim: ['key', 'words']
     }
   end
 
   it 'has the uv html on the page' do
     visit solr_document_path(id)
     expect(page.html).to match(/universal-viewer-iframe/)
+  end
+
+  it 'has title, creator, date created, and content type on the page' do
+    visit solr_document_path(id)
+    expect(page).to have_content('The Title of my Work')
+    expect(page).to have_content('Smith, Somebody')
+    expect(page).to have_content('Contributor, Jack')
+    expect(page).to have_content('1776')
+    expect(page).to have_content('XXXX')
+    expect(page).to have_content('192?')
+    expect(page).to have_content('1973?')
+    expect(page).to have_content('1652')
+    expect(page).to have_content('This is a uniform title')
+    expect(page).to have_content('This is a series title')
+    expect(page).to have_content('This is a parent title')
+    expect(page).to have_content('Description or abstract of work')
+    expect(page).to have_content('English')
+    expect(page).to have_content('Text')
+    expect(page).to have_content('Painting')
+    expect(page).to have_content('State')
+    expect(page).to have_content('1985')
+    expect(page).to have_content('notes about a thing')
+    expect(page).to have_content('Edo (African)')
+    expect(page).to have_content('Qāsimlū, Mujtabá')
+    expect(page).to have_content('New Jersey')
+    expect(page).to have_content('key')
+    expect(page).to have_content('words')
   end
 end


### PR DESCRIPTION
"About this item" and "Keywords" (see https://docs.google.com/spreadsheets/d/1bODcf-cLwBNOv7UDtNE39M1OoRW93o6xRVDZMGX-eaQ/edit#gid=696928716) sections of metadata added to Show page. (image 1)

![image](https://user-images.githubusercontent.com/45948126/70584970-c30ef780-1b90-11ea-93fb-1e7423c625cf.png)

Also did first pass at adding facets to verify Solr index. While they look good at first glance, the Curate-created Solr index will need to be updated for many of the faceted fields to appear correctly (e.g. "New Jersey" appears as "new" and "jersey" because of how it is stored in the Solr index)
![image](https://user-images.githubusercontent.com/45948126/70585036-e8036a80-1b90-11ea-9090-cd92ad11cba7.png)

![image](https://user-images.githubusercontent.com/45948126/70585106-200aad80-1b91-11ea-9728-f097a9c5826d.png)
