### PR TITLE
Update metadata groupings

### DIFF
--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,7 +1,7 @@
 $(document).on('turbolinks:load', function() {
-  $('#universal-viewer-iframe').width($('.uv-container').width())
+  $('.universal-viewer-iframe').width($('.uv-container').width())
 
   $(window).on('resize', function(){
-    $('#universal-viewer-iframe').width($('.uv-container').width())
+    $('.universal-viewer-iframe').width($('.uv-container').width())
   })
 })

--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -29,7 +29,7 @@ module Blacklight
     # Classes used for sizing the main content of a Blacklight page
     # @return [String]
     def main_content_classes
-      'col-lg-12'
+      'col-lg-12 col-md-12'
     end
 
     ##

--- a/app/views/catalog/_about_this_item.html.erb
+++ b/app/views/catalog/_about_this_item.html.erb
@@ -1,14 +1,1 @@
-<div class="about-this-item">
-  <% doc_presenter = show_presenter(document) %>
-  <% about = AboutThisItemPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if about.length > 0 %>
-    <h2>About This Item</h2>
-    <dl class="row">
-    <% about.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item' %>

--- a/app/views/catalog/_access_and_copyright.html.erb
+++ b/app/views/catalog/_access_and_copyright.html.erb
@@ -1,14 +1,1 @@
-<div class="access-and-copyright">
-  <% doc_presenter = show_presenter(document) %>
-  <% about = AccessAndCopyrightPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if about.length > 0 %>
-    <h2>Access and Copyright</h2>
-    <dl class="row">
-    <% about.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: AccessAndCopyrightPresenter, presenter_class: 'access-and-copyright', title: 'Access and Copyright' %>

--- a/app/views/catalog/_find_this_item.html.erb
+++ b/app/views/catalog/_find_this_item.html.erb
@@ -1,15 +1,1 @@
-<div class="find-this-item">
-
-  <% doc_presenter = show_presenter(document) %>
-  <% find = FindThisItemPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if find.length > 0 %>
-    <h2>Find This Item</h2>
-    <dl class="row">
-    <% find.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: FindThisItemPresenter, presenter_class: 'find-this-item', title: 'Find This Item' %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -5,10 +5,10 @@
   <dt class="col-sm-3"><%= render_document_partials document,
     [:thumbnail] %></dt>
   <dd class="col-sm-9">
-    <dl class="document-metadata dl-invert row">
+    <dl>
       <% doc_presenter.fields_to_render.each do |field_name, field| -%>
-        <dt class="blacklight-<%= field_name.parameterize %> col-sm-4"><%= render_index_field_label document, field: field_name %></dt>
-        <dd class="blacklight-<%= field_name.parameterize %> col-sm-8"><%= doc_presenter.field_value field %></dd>
+        <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
+        <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
       <% end -%>
     </dl>
   </dd>

--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -1,0 +1,15 @@
+<% doc_presenter = show_presenter(document) %>
+<% fields = presenter.new(document: doc_presenter.fields_to_render).terms %>
+<% if fields.length > 0 %>
+  <div class="<%= presenter_class %> card mb-2">
+    <div class="card-header"><%= title %></div>
+    <div class="card-body">
+      <dl>
+        <% fields.each do |field_name, field| %>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_metadata_groupings.html.erb
+++ b/app/views/catalog/_metadata_groupings.html.erb
@@ -1,38 +1,38 @@
-<div class="row">
-  <div class="col-md-3">
+<div class="row mb-2">
+  <div class="col-lg-4">
     <%= render "is_part_of" %>
   </div>
-  <div class="col-md-7">
+  <div class="col-lg-4">
     <%= render "about_this_item", document: document %>
   </div>
-  <div class="col-md-2">
+  <div class="col-lg-4">
     <%= render 'show_tools', document: document %>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-3">
+<div class="row mb-2">
+  <div class="col-lg-4">
     <%= render "contains", document: document %>
   </div>
-  <div class="col-md-7">
+  <div class="col-lg-4">
     <%= render "subjects_keywords", document: document %>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-3">
+<div class="row mb-2">
+  <div class="col-lg-4">
     <%= render "find_this_item", document: document %>
   </div>
-  <div class="col-md-7">
+  <div class="col-lg-4">
     <%= render "publication_details", document: document %>
   </div>
-  <div class="col-md-2">
+  <div class="col-lg-4">
     <%= render "access_and_copyright", document: document %>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-3">
+<div class="row mb-2">
+  <div class="col-lg-4">
     <%= render "related_material", document: document %>
   </div>
-  <div class="col-md-7">
+  <div class="col-lg-4">
     <%= render "misc_details", document: document %>
   </div>
 </div>

--- a/app/views/catalog/_misc_details.html.erb
+++ b/app/views/catalog/_misc_details.html.erb
@@ -1,14 +1,1 @@
-<div class="misc-details">
-  <% doc_presenter = show_presenter(document) %>
-  <% terms = MiscDetailsPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if terms.length > 0 %>
-    <h2>Misc Details</h2>
-    <dl class="row">
-    <% terms.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: MiscDetailsPresenter, presenter_class: 'misc-details', title: 'Misc Details' %>

--- a/app/views/catalog/_publication_details.html.erb
+++ b/app/views/catalog/_publication_details.html.erb
@@ -1,14 +1,1 @@
-<div class="publication-details">
-  <% doc_presenter = show_presenter(document) %>
-  <% about = PublicationDetailsPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if about.length > 0 %>
-    <h2>Publication Details</h2>
-    <dl class="row">
-    <% about.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: PublicationDetailsPresenter, presenter_class: 'publication-details', title: 'Publication Details' %>

--- a/app/views/catalog/_related_material.html.erb
+++ b/app/views/catalog/_related_material.html.erb
@@ -1,14 +1,1 @@
-<div class="related-material">
-  <% doc_presenter = show_presenter(document) %>
-  <% terms = RelatedMaterialPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if terms.length > 0 %>
-    <h2>Related Material</h2>
-    <dl class="row">
-    <% terms.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: RelatedMaterialPresenter, presenter_class: 'related-material', title: 'Related Material' %>

--- a/app/views/catalog/_subjects_keywords.html.erb
+++ b/app/views/catalog/_subjects_keywords.html.erb
@@ -1,14 +1,1 @@
-<div class="subjects-keywords">
-  <% doc_presenter = show_presenter(document) %>
-  <% terms = SubjectsKeywordsPresenter.new(document: doc_presenter.fields_to_render).terms %>
-
-  <% if terms.length > 0 %>
-    <h2>Subjects / Keywords</h2>
-    <dl class="row">
-    <% terms.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>
-    <% end %>
-    </dl>
-  <% end %>
-</div>
+<%= render 'metadata_block', document: document, presenter: SubjectsKeywordsPresenter, presenter_class: 'subjects-keywords', title: 'Subjects / Keywords' %>


### PR DESCRIPTION
This alters the partials so that have better
spacing and changes the layout in the grouping
so that the header is on a different row than
the value.

There is a new partial that can be used to output
a metadata block. It can be used like this:

```ruby
<%= render 'metadata_block', document: document, presenter: AccessAndCopyrightPresenter, presenter_class: 'access-and-copyright', title: 'Access and Copyright' %>
```