### PR TITLE
Remove partial for This item contains

### DIFF
--- a/app/views/catalog/_contains.html.erb
+++ b/app/views/catalog/_contains.html.erb
@@ -1,3 +1,0 @@
-<div class="contains">
-  <h3>This item contains:</h3>
-</div>

--- a/app/views/catalog/_metadata_groupings.html.erb
+++ b/app/views/catalog/_metadata_groupings.html.erb
@@ -11,9 +11,6 @@
 </div>
 <div class="row mb-2">
   <div class="col-lg-4">
-    <%= render "contains", document: document %>
-  </div>
-  <div class="col-lg-4">
     <%= render "subjects_keywords", document: document %>
   </div>
 </div>

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -25,8 +25,6 @@ RSpec.feature "View a Work" do
     expect(page).to have_content('This item is part of:')
     expect(page).to have_css('.about-this-item')
     expect(page).to have_content('About This Item')
-    expect(page).to have_css('.contains')
-    expect(page).to have_content('This item contains:')
     expect(page).to have_css('.subjects-keywords')
     expect(page).to have_content('Subjects / Keywords')
     expect(page).to have_css('.find-this-item')


### PR DESCRIPTION
Given the conversation on #154, the "This item contains" section does not apply to a simple object show page, so its corresponding partial is now removed.