### PR TITLE
Add advanced_search gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/BlockLength:
     Exclude:
         - 'spec/**/*'
         - 'app/controllers/catalog_controller.rb'
+        - 'config/routes.rb'
 
 Metrics/AbcSize:
     Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby '>=2.5.0'
 
 # Trying Blacklight 7 for comparison to 6
 gem 'blacklight', ">= 7"
+gem 'blacklight_advanced_search', git: 'https://github.com/projectblacklight/blacklight_advanced_search'
 gem 'dotenv-rails'
 gem 'honeybadger', '~> 4.0'
 gem 'mysql2', '~> 0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       colorize
       terminal-table
 
+GIT
+  remote: https://github.com/projectblacklight/blacklight_advanced_search
+  revision: 4e2ba68f30cb0bccf345be46bc8299c71cb59c5a
+  specs:
+    blacklight_advanced_search (7.0.0.alpha)
+      blacklight (~> 7.0)
+      parslet
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -1044,6 +1052,7 @@ GEM
     parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    parslet (1.8.2)
     popper_js (1.14.5)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -1252,6 +1261,7 @@ DEPENDENCIES
   bixby
   blacklight (>= 7)
   blacklight-marc (>= 7.0.0.rc1)
+  blacklight_advanced_search!
   bootstrap (~> 4.0)
   byebug
   cap-ec2-emory!

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,13 +12,22 @@
  *
  *= require_tree .
  *= require_self
- */
+ 
+ *= require 'blacklight_advanced_search'
+
+*/
  /* .document-thumbnail img {
      max-width: 150px;
      vertical-align: top;
      float: left;
- } */
+ } 
+ *= require 'blacklight_advanced_search'
+
+*/
 
  /* .document-metadata dt {
     align: left;
- } */
+ } 
+ *= require 'blacklight_advanced_search'
+
+*/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class CatalogController < ApplicationController
+  include BlacklightAdvancedSearch::Controller
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
 
@@ -8,6 +9,13 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    # default advanced config values
+    config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+    # config.advanced_search[:qt] ||= 'advanced'
+    config.advanced_search[:url_key] ||= 'advanced'
+    config.advanced_search[:query_parser] ||= 'dismax'
+    config.advanced_search[:form_solr_parameters] ||= {}
+
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
     #

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SavedSearchesController < ApplicationController
+  include Blacklight::SavedSearches
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
 
   ##
   # @example Adding a new step to the processor chain

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search' do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <% if search_fields.length > 1 %>
+    <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+  <% end %>
+  <div class="input-group">
+    <% if search_fields.length > 1 %>
+        <%= select_tag(:search_field,
+                       options_for_select(search_fields, h(params[:search_field])),
+                       title: t('blacklight.search.form.search_field.title'),
+                       id: "search_field",
+                       class: "custom-select search-field") %>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
+    <% end %>
+
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+
+    <span class="input-group-append">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <%= blacklight_icon :search, aria_hidden: true %>
+      </button>
+    </span>
+  </div>
+<% end %>
+
+
+
+<div>
+  <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
+  mount BlacklightAdvancedSearch::Engine => '/'
+
   concern :marc_viewable, Blacklight::Marc::Routes::MarcViewable.new
 
   root to: "catalog#index"

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search the catalog using advanced search', type: :system, js: false do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add([orange, banana])
+    solr.add([creator,
+              contributors,
+              abstract,
+              table_of_contents,
+              keywords,
+              subject_topics,
+              subject_names,
+              subject_geo,
+              parent_title,
+              uniform_title,
+              publisher,
+              creator_of_collection])
+    solr.commit
+  end
+
+  let(:orange) do
+    {
+      id: '111',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Orange Carrot'],
+      photographer_tesim: ['Bittersweet Tangerine'],
+      description_tesim: ['Long description Long description Long description Long description Long description Long description'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:banana) do
+    {
+      id: '222',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Yellow Banana'],
+      photographer_tesim: ['Buff Saffron'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:creator) do
+    {
+      id: '333',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in creator',
+      creator_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:contributors) do
+    {
+      id: '444',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in contributors',
+      contributors_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:abstract) do
+    {
+      id: '555',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in abstract',
+      abstract_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:table_of_contents) do
+    {
+      id: '666',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in table of contents',
+      table_of_contents_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:keywords) do
+    {
+      id: '777',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in keywords',
+      keywords_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:subject_topics) do
+    {
+      id: '888',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in subject topics',
+      subject_topics_tesim: ['3Guv4P44'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:subject_names) do
+    {
+      id: '999',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in subject names',
+      subject_names_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:subject_geo) do
+    {
+      id: '101010',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in subject geo',
+      subject_geo_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:parent_title) do
+    {
+      id: '111111',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in parent title',
+      parent_title_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:uniform_title) do
+    {
+      id: '121212',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in uniform title',
+      uniform_title_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:publisher) do
+    {
+      id: '131313',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: 'Target in publisher',
+      publisher_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:creator_of_collection) do
+    {
+      id: '141414',
+      has_model_ssim: ['Collection'],
+      title_tesim: 'Target in creator, model is collection',
+      creator_tesim: ['iMCnR6E8'],
+      visibility_ssi: ['open']
+    }
+  end
+
+  it 'gets correct search results from all fields' do
+    visit root_path
+    click_on "More options"
+    # Search for something
+    fill_in 'all_fields', with: 'carrot'
+    click_on 'advanced-search-submit'
+
+    within '#documents' do
+      expect(page).to     have_content('Orange Carrot')
+      expect(page).not_to have_content('Yellow Banana')
+    end
+  end
+
+  xit 'gets correct search results from title field' do
+    visit root_path
+    click_on "More options"
+    # Search for something
+    fill_in 'title', with: 'carrot'
+    click_on 'advanced-search-submit'
+
+    within '#documents' do
+      expect(page).to     have_content('Orange Carrot')
+      expect(page).not_to have_content('Yellow Banana')
+    end
+  end
+end


### PR DESCRIPTION
- The `blacklight_advanced_search` gem was added from git because there has not yet been a release compatible with Blacklight 7
- We will reach out to the community to find out why there has not been a recent release
- This PR does not actually add advanced search functionality because the problem seems to stem from an existing problem with drop-down search in Lux, which will be addressed in a future sprint