### PR TITLE
Remove unneeded controllers

### DIFF
--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class SavedSearchesController < ApplicationController
-  include Blacklight::SavedSearches
-
-  helper BlacklightAdvancedSearch::RenderConstraintsOverride
-end

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class SearchHistoryController < ApplicationController
-  include Blacklight::SearchHistory
-
-  helper BlacklightAdvancedSearch::RenderConstraintsOverride
-end


### PR DESCRIPTION
These controllers were added by blacklight_advanced_search plugin, but they were causing problems with deploy. We cannot find any requirements for saved searches, so we are removing them.