### PR TITLE
Configure targeted search fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -33,8 +33,10 @@ class CatalogController < ApplicationController
       qt: 'search',
       mm: '100%',
       rows: 10,
-      qf: 'title_tesim creator_tesim contributors_tesim abstract_tesim table_of_contents_tesim keywords_tesim
-           subject_topics_tesim subject_names_tesim subject_geo_tesim parent_title_tesim uniform_title_tesim publisher_tesim id',
+      qf: 'system_of_record_ID_tesim primary_repository_ID_tesim emory_ark_tesim local_call_number_tesim
+           other_identifiers_tesim title_tesim uniform_title_tesim series_title_tesim parent_title_tesim
+           creator_tesim contributors_tesim keywords_tesim subject_topics_tesim subject_names_tesim
+           subject_geo_tesim subject_time_periods_tesim id',
       fq: '(((has_model_ssim:CurateGenericWork) OR (has_model_ssim:Collection)) AND (visibility_ssi:open))'
       ### we want to only return works where visibility_ssi == open (not restricted)
     }
@@ -225,18 +227,64 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', label: 'All Fields'
+    config.add_search_field 'common_fields', label: 'Common Fields'
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
 
-    config.add_search_field('title') do |field|
+    # config.add_search_field('title') do |field|
+    #   # solr_parameters hash are sent to Solr as ordinary url query params.
+    #   field.solr_parameters = {
+    #     'spellcheck.dictionary': 'title',
+    #     qf: '${title_qf}',
+    #     pf: '${title_pf}'
+    #   }
+    # end
+
+    id_fields =       ['system_of_record_ID_tesim', 'primary_repository_ID_tesim', 'emory_ark_tesim',
+                       'local_call_number_tesim', 'other_identifiers_tesim']
+    title_fields =    ['title_tesim', 'uniform_title_tesim', 'series_title_tesim', 'parent_title_tesim']
+    creator_fields =  ['creator_tesim', 'contributors_tesim']
+    subject_fields =  ['keywords_tesim', 'subject_topics_tesim', 'subject_names_tesim', 'subject_geo_tesim',
+                       'subject_time_periods_tesim']
+    misc_fields =     ['institution_tesim', 'primary_language_tesim', 'publisher_tesim', 'holding_repository_tesim',
+                       'related_material_notes_tesim', 'place_of_production_tesim', 'administrative_unit_tesim',
+                       'conference_name_tesim', 'sublocation_tesim', 'sponsor_tesim', 'data_producers_tesim',
+                       'grant_agencies_tesim', 'content_genres_tesim', 'grant_information_tesim', 'author_notes_tesim',
+                       'notes_tesim', 'data_source_notes_tesim', 'geographic_unit_tesim', 'technical_note_tesim',
+                       'issn_tesim', 'isbn_tesim', 'abstract_tesim', 'related_publications_tesim', 'related_datasets_tesim',
+                       'table_of_contents_tesim']
+
+    config.add_search_field('title', label: 'Title') do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
       field.solr_parameters = {
-        'spellcheck.dictionary': 'title',
-        qf: '${title_qf}',
-        pf: '${title_pf}'
+        qf: title_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('creator', label: 'Creator') do |field|
+      # solr_parameters hash are sent to Solr as ordinary url query params.
+      field.solr_parameters = {
+        qf: creator_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('subject', label: 'Subject') do |field|
+      # solr_parameters hash are sent to Solr as ordinary url query params.
+      field.solr_parameters = {
+        qf: subject_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('all_fields', label: 'All Fields') do |field|
+      # solr_parameters hash are sent to Solr as ordinary url query params.
+      field.solr_parameters = {
+        qf: (id_fields + title_fields + creator_fields + subject_fields + misc_fields).join(' '),
+        pf: ''
       }
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe CatalogController, type: :controller do
 
     let(:expected_search_fields) do
       ['all_fields',
+       'common_fields',
+       'creator',
+       'subject',
        'title']
     end
 

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -196,8 +196,6 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       expect(result_titles).to contain_exactly(
         'Target in creator',
         'Target in contributors',
-        'Target in abstract',
-        'Target in table of contents',
         'Target in keywords',
         'Target in subject topics'
       )
@@ -216,7 +214,6 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
         'Target in subject geo',
         'Target in parent title',
         'Target in uniform title',
-        'Target in publisher',
         'Target in creator, model is collection'
       )
     end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Search the catalog', type: :system, js: false do
+  let(:fields) do
+    ['system_of_record_ID',
+     'primary_repository_ID',
+     'emory_ark',
+     'local_call_number',
+     'other_identifiers',
+     'uniform_title',
+     'series_title',
+     'parent_title',
+     'creator',
+     'contributors',
+     'keywords',
+     'subject_topics',
+     'subject_names',
+     'subject_geo',
+     'subject_time_periods',
+     'institution',
+     'primary_language',
+     'publisher',
+     'holding_repository',
+     'related_material_notes',
+     'place_of_production',
+     'administrative_unit',
+     'conference_name',
+     'sublocation',
+     'sponsor',
+     'data_producers',
+     'grant_agencies',
+     'content_genres',
+     'grant_information',
+     'author_notes',
+     'notes',
+     'data_source_notes',
+     'geographic_unit',
+     'technical_note',
+     'issn',
+     'isbn',
+     'abstract',
+     'related_publications',
+     'related_datasets',
+     'table_of_contents']
+  end
+
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    fields.each_with_index do |f, i|
+      solr.add(
+        id: i.to_s,
+        has_model_ssim: ['CurateGenericWork'],
+        title_tesim: "Target in #{f}",
+        "#{f}_tesim".to_sym => ['iMCnR6E8'],
+        visibility_ssi: ['open']
+      )
+    end
+
+    # Handle special case of targeted title field
+    solr.add(
+      id: '9999',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Target in title iMCnR6E8'],
+      visibility_ssi: ['open']
+    )
+    solr.commit
+  end
+
+  it 'searches the right fields for Common Fields target' do
+    visit root_path
+    page.select('Common Fields', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+
+    result_titles = []
+    loop do
+      within '#documents' do
+        result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      end
+      break if page.has_link?('Next', href: '#')
+      click_link('Next', match: :first)
+    end
+
+    expect(result_titles).to contain_exactly(
+      'Target in system_of_record_ID',
+      'Target in primary_repository_ID',
+      'Target in emory_ark',
+      'Target in local_call_number',
+      'Target in other_identifiers',
+      'Target in title iMCnR6E8',
+      'Target in uniform_title',
+      'Target in series_title',
+      'Target in parent_title',
+      'Target in creator',
+      'Target in contributors',
+      'Target in keywords',
+      'Target in subject_topics',
+      'Target in subject_names',
+      'Target in subject_geo',
+      'Target in subject_time_periods'
+    )
+  end
+
+  it 'searches the right fields for Title target' do
+    visit root_path
+    page.select('Title', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+
+    within '#documents' do
+      result_titles = page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      expect(result_titles).to contain_exactly(
+        'Target in title iMCnR6E8',
+        'Target in uniform_title',
+        'Target in series_title',
+        'Target in parent_title'
+      )
+    end
+  end
+
+  it 'searches the right fields for Creator target' do
+    visit root_path
+    page.select('Creator', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+
+    within '#documents' do
+      result_titles = page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      expect(result_titles).to contain_exactly(
+        'Target in creator',
+        'Target in contributors'
+      )
+    end
+  end
+
+  it 'searches the right fields for Subject target' do
+    visit root_path
+    page.select('Subject', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+
+    within '#documents' do
+      result_titles = page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      expect(result_titles).to contain_exactly(
+        'Target in keywords',
+        'Target in subject_topics',
+        'Target in subject_names',
+        'Target in subject_geo',
+        'Target in subject_time_periods'
+      )
+    end
+  end
+
+  it 'search the right fields for All Fields target' do
+    visit root_path
+    page.select('All Fields', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+
+    result_titles = []
+
+    loop do
+      within '#documents' do
+        result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      end
+      break if page.has_link?('Next', href: '#')
+      click_link('Next', match: :first)
+    end
+
+    expect(result_titles).to contain_exactly(
+      'Target in system_of_record_ID',
+      'Target in primary_repository_ID',
+      'Target in emory_ark',
+      'Target in local_call_number',
+      'Target in other_identifiers',
+      'Target in title iMCnR6E8',
+      'Target in uniform_title',
+      'Target in series_title',
+      'Target in parent_title',
+      'Target in creator',
+      'Target in contributors',
+      'Target in keywords',
+      'Target in subject_topics',
+      'Target in subject_names',
+      'Target in subject_geo',
+      'Target in subject_time_periods',
+      'Target in institution',
+      'Target in primary_language',
+      'Target in publisher',
+      'Target in holding_repository',
+      'Target in related_material_notes',
+      'Target in place_of_production',
+      'Target in administrative_unit',
+      'Target in conference_name',
+      'Target in sublocation',
+      'Target in sponsor',
+      'Target in data_producers',
+      'Target in grant_agencies',
+      'Target in content_genres',
+      'Target in grant_information',
+      'Target in author_notes',
+      'Target in notes',
+      'Target in data_source_notes',
+      'Target in geographic_unit',
+      'Target in technical_note',
+      'Target in issn',
+      'Target in isbn',
+      'Target in abstract',
+      'Target in related_publications',
+      'Target in related_datasets',
+      'Target in table_of_contents'
+    )
+  end
+end


### PR DESCRIPTION
- Fields specified in #125 are added to targeted search
- `catalog_controller_spec.rb` and `search_catalog_spec.rb` are updated to match new search requirements