### PR TITLE
Remove facets from advanced search page

### DIFF
--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,0 +1,33 @@
+<!-- [Blacklight Advanced Search overwrite] Remove markup for facets on advanced search page #L26 -->
+
+<% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
+    <div class="constraints well search_history">
+      <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
+      <%= search_context_str %>
+    </div>
+  <% end %>
+
+<%= form_tag search_catalog_path, :class => 'advanced form-horizontal', :method => :get do  %>
+
+  <%= render_hash_as_hidden_fields(advanced_search_context) %>
+
+  <div class="input-criteria">
+
+      <div class="query-criteria">
+        <h3 class="query-criteria-heading">
+          <%= t('blacklight_advanced_search.form.query_criteria_heading_html', :select_menu =>  select_menu_for_field_operator ) %> 
+        </h3>
+
+        <div id="advanced_search">
+          <%= render 'advanced/advanced_search_fields' %>
+        </div>
+      </div>
+  </div>
+
+  <hr>
+
+  <div class="sort-submit-buttons clearfix">
+    <%= render 'advanced_search_submit_btns' %>
+  </div>
+
+<% end %>

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -194,4 +194,10 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
     click_on "More options"
     expect(page).to have_no_css('.search-query-form')
   end
+
+  it 'does not display facets' do
+    visit root_path
+    click_on "More options"
+    expect(page).to have_no_css('.limit-criteria')
+  end
 end


### PR DESCRIPTION
Facets on the advanced search page exhibit unexpected behavior (see #218). Because there are no known requirements specifying their presence, they are being removed.