### PR TITLE
Allow facet options to be sorted alphabetically

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -102,20 +102,20 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'holding_repository_sim', label: 'Library'
-    config.add_facet_field 'member_of_collections_ssim', label: 'Collection'
-    config.add_facet_field 'creator_sim', label: 'Creator'
-    config.add_facet_field 'human_readable_content_type_ssim', label: 'Format'
-    config.add_facet_field 'content_genres_sim', label: 'Genre'
-    config.add_facet_field 'primary_language_sim', label: 'Language'
+    config.add_facet_field 'holding_repository_sim', limit: 5, label: 'Library'
+    config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collection'
+    config.add_facet_field 'creator_sim', limit: 5, label: 'Creator'
+    config.add_facet_field 'human_readable_content_type_ssim', limit: 5, label: 'Format'
+    config.add_facet_field 'content_genres_sim', limit: 5, label: 'Genre'
+    config.add_facet_field 'primary_language_sim', limit: 5, label: 'Language'
     config.add_facet_field 'year_for_lux_isim', label: 'Date',
                                                 range: {
                                                   assumed_boundaries: [1000, Time.zone.now.year],
                                                   maxlength: 4
                                                 }
-    config.add_facet_field 'subject_topics_sim', label: 'Subject - Topics'
-    config.add_facet_field 'subject_names_sim', label: 'Subject - Names'
-    config.add_facet_field 'subject_geo_sim', label: 'Subject - Geographic Locations'
+    config.add_facet_field 'subject_topics_sim', limit: 5, label: 'Subject - Topics'
+    config.add_facet_field 'subject_names_sim', limit: 5, label: 'Subject - Names'
+    config.add_facet_field 'subject_geo_sim', limit: 5, label: 'Subject - Geographic Locations'
     config.add_facet_field 'human_readable_rights_statement_ssim', label: 'Rights Status'
 
     #config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true


### PR DESCRIPTION
If a facet (besides Date and Rights Status) has more than 5 options, those options can be sorted either alphabetically or numerically. The default is numerical sorting.

![Screen Shot 2020-01-22 at 3 31 33 PM](https://user-images.githubusercontent.com/46227821/72931692-56a91b80-3d2c-11ea-9a47-5b5aadec158f.png)
