### PR TITLE
Emory high view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Metrics/PerceivedComplexity:
     Exclude:
         - 'app/models/marc_indexer.rb'
 
+RSpec/DescribeClass:
+    Exclude:
+        - 'spec/system/visibility_spec.rb'
+
 RSpec/ExampleLength:
     Exclude:
         - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ ruby '>=2.5.0'
 # gem 'bcrypt', '~> 3.1.7'
 # Blacklight 7, because Blacklight 6 did not successfully deploy to production
 gem 'blacklight', ">= 7"
+gem 'blacklight-access_controls'
 gem 'blacklight-marc', '>= 7.0.0.rc1'
 gem 'blacklight_advanced_search', '~>7.0'
 gem 'blacklight_range_limit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -885,6 +885,10 @@ GEM
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
+    blacklight-access_controls (6.0.0)
+      blacklight (> 6.0, < 8)
+      cancancan (~> 1.8)
+      deprecation (~> 1.0)
     blacklight-marc (7.0.0.rc1)
       blacklight (> 7.0.0.a, < 8.a)
       library_stdnums
@@ -903,6 +907,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.3)
     byebug (11.0.1)
+    cancancan (1.17.0)
     capistrano (3.11.2)
       airbrussh (>= 1.0.0)
       i18n
@@ -1257,6 +1262,7 @@ PLATFORMS
 DEPENDENCIES
   bixby
   blacklight (>= 7)
+  blacklight-access_controls
   blacklight-marc (>= 7.0.0.rc1)
   blacklight_advanced_search (~> 7.0)
   blacklight_range_limit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,10 @@ class ApplicationController < ActionController::Base
   layout :determine_layout if respond_to? :layout
 
   protect_from_forgery with: :exception
+
+  rescue_from Blacklight::AccessControls::AccessDenied, with: :render_404
+
+  def render_404
+    render file: Rails.root.join('public', '404.html'), status: :not_found, layout: false
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,11 @@ class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include BlacklightAdvancedSearch::Controller
   include Blacklight::Catalog
+  include Blacklight::AccessControls::Catalog
+
+  # Apply the blacklight-access_controls
+  before_action :enforce_show_permissions, only: :show
+
   include Blacklight::Marc::Catalog
 
   def guest_uid_authentication_key(key)
@@ -38,8 +43,7 @@ class CatalogController < ApplicationController
            other_identifiers_tesim title_tesim uniform_title_tesim series_title_tesim parent_title_tesim
            creator_tesim contributors_tesim keywords_tesim subject_topics_tesim subject_names_tesim
            subject_geo_tesim subject_time_periods_tesim id',
-      fq: '(((has_model_ssim:CurateGenericWork) OR (has_model_ssim:Collection)) AND (visibility_ssi:open))'
-      ### we want to only return works where visibility_ssi == open (not restricted)
+      fq: '((has_model_ssim:CurateGenericWork) OR (has_model_ssim:Collection))'
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Ability
+  include Blacklight::AccessControls::Ability
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -8,9 +8,9 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   ##
   # @example Adding a new step to the processor chain
-    # self.default_processor_chain += [:add_custom_data_to_query]
-    #
-    # def add_custom_data_to_query(solr_parameters)
-    #   solr_parameters[:custom] = blacklight_params[:user_value]
-    # end
+  # self.default_processor_chain += [:add_custom_data_to_query]
+  #
+  # def add_custom_data_to_query(solr_parameters)
+  #   solr_parameters[:custom] = blacklight_params[:user_value]
+  # end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -8,9 +8,9 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   ##
   # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+    # self.default_processor_chain += [:add_custom_data_to_query]
+    #
+    # def add_custom_data_to_query(solr_parameters)
+    #   solr_parameters[:custom] = blacklight_params[:user_value]
+    # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 class User < ApplicationRecord
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
+  include Blacklight::AccessControls::User
+
 
   class NilShibbolethUserError < RuntimeError
     attr_accessor :auth

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   include Blacklight::User
   include Blacklight::AccessControls::User
 
-
   class NilShibbolethUserError < RuntimeError
     attr_accessor :auth
 

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,11 +1,13 @@
-<div class="uv-container">
-  <iframe
-      class="universal-viewer-iframe"
-      src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= Rails.application.config.iiif_url %>/<%= document.id %>/manifest"
-      width="924px"
-      height="668px"
-      allowfullscreen
-      frameborder="0">
-  </iframe>
-</div>
-</br>
+<% if can?(:read, document) %>
+  <div class="uv-container">
+    <iframe
+        class="universal-viewer-iframe"
+        src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= Rails.application.config.iiif_url %>/<%= document.id %>/manifest"
+        width="924px"
+        height="668px"
+        allowfullscreen
+        frameborder="0">
+    </iframe>
+  </div>
+  </br>
+<% end %>

--- a/config/initializers/blacklight_access_controls.rb
+++ b/config/initializers/blacklight_access_controls.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Blacklight::AccessControls.configure do |config|
+  # This specifies the solr field names of permissions-related fields.
+  # The default fields used are shown below, if you index your permissions to other fields update the configuration below.
+  # If you change these, you must also update the permissions request handler in your solrconfig.xml to return those values
+  #
+  # config.discover_group_field = Solrizer.solr_name("discover_access_group", :symbol)
+  # config.discover_user_field  = Solrizer.solr_name("discover_access_person", :symbol)
+  # config.read_group_field     = Solrizer.solr_name("read_access_group", :symbol)
+  # config.read_user_field      = Solrizer.solr_name("read_access_person", :symbol)
+  # config.download_group_field = Solrizer.solr_name("download_access_group", :symbol)
+  # config.download_user_field  = Solrizer.solr_name("dowload_access_person", :symbol)
+  #
+  # specify the user model
+  # config.user_model = 'User'
+end

--- a/spec/support/solr_documents/collection.rb
+++ b/spec/support/solr_documents/collection.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 COLLECTION = {
   has_model_ssim: ["Collection"],
+  visibility_ssi: "open",
+  read_access_group_ssim: ["public"],
   id: "119f4qrfj9-cor",
   accessControl_ssim: ["38cd37a4-9437-4ecf-868f-bbdb290b2341"],
   title_tesim: ["Chester W. Topp collection of Victorian yellowbacks and paperbacks"],
@@ -29,8 +31,6 @@ COLLECTION = {
   thumbnail_path_ss: "/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png",
   generic_type_sim: ["Collection"],
   bytes_lts: 312_470_524,
-  visibility_ssi: "open",
-  read_access_group_ssim: ["public"],
   edit_access_person_ssim: ["tmiles2"],
   human_readable_type_sim: "Collection",
   human_readable_type_tesim: "Collection"

--- a/spec/support/solr_documents/curate_generic_work.rb
+++ b/spec/support/solr_documents/curate_generic_work.rb
@@ -3,6 +3,7 @@ CURATE_GENERIC_WORK = {
   id: ['123'],
   has_model_ssim: ['CurateGenericWork'],
   visibility_ssi: ['open'],
+  read_access_group_ssim: ["public"],
   title_tesim: ['The Title of my Work'],
   uniform_title_tesim: ['This is a uniform title'],
   series_title_tesim: ['This is a series title'],

--- a/spec/system/view_unauthorized_spec.rb
+++ b/spec/system/view_unauthorized_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "View a work you aren't authorized to see", js: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([restricted_work])
+    solr.commit
+  end
+
+  let(:work_id) { '123' }
+
+  let(:restricted_work) do
+    {
+      id: work_id,
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Restricted Work']
+    }
+  end
+
+  it 'denies access' do
+    visit solr_document_path(work_id)
+    expect(page).to have_content 'The page you were looking for doesn\'t exist'
+  end
+end

--- a/spec/system/visibility_spec.rb
+++ b/spec/system/visibility_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe "View an Emory High Resolution Work", js: true do
+RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
   context 'as a guest user' do
     before do
       solr = Blacklight.default_index.connection
@@ -43,7 +43,7 @@ RSpec.describe "View an Emory High Resolution Work", js: true do
 
       # Shouldn't see Universal Viewer
       visit solr_document_path(emory_high_work_id)
-      expect(page).to_not have_selector(css_selector_for_uv)
+      expect(page).not_to have_selector(css_selector_for_uv)
     end
   end
   context 'as a logged in user' do

--- a/spec/system/visibility_spec.rb
+++ b/spec/system/visibility_spec.rb
@@ -39,11 +39,12 @@ RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
     it 'only displays Universal Viewer if user has at least "read"-level access' do
       # Should see Universal Viewer
       visit solr_document_path(open_work_id)
-      expect(page).to have_selector(css_selector_for_uv)
+      expect(page).to have_content 'Work with Open Access'
 
       # Shouldn't see Universal Viewer
       visit solr_document_path(emory_high_work_id)
-      expect(page).not_to have_selector(css_selector_for_uv)
+      expect(page).not_to have_content 'Work with Emory High visibility'
+      expect(page).to have_content 'The page you were looking for doesn\'t exist'
     end
   end
   context 'as a logged in user' do
@@ -63,7 +64,7 @@ RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
       {
         id: emory_high_work_id,
         has_model_ssim: ['CurateGenericWork'],
-        title_tesim: ['Work with Emory Low visibility'],
+        title_tesim: ['Work with Emory High visibility'],
         edit_access_group_ssim: ["admin"],
         read_access_group_ssim: ["registered"],
         visibility_ssi: ['authenticated']
@@ -85,11 +86,12 @@ RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
     it 'only displays Universal Viewer if user has at least "read"-level access' do
       # Should see Universal Viewer
       visit solr_document_path(open_work_id)
-      expect(page).to have_selector(css_selector_for_uv)
+      expect(page).to have_content 'Work with Open Access'
 
       # Shouldn't see Universal Viewer
       visit solr_document_path(emory_high_work_id)
-      expect(page).to have_selector(css_selector_for_uv)
+      expect(page).to have_content 'Work with Emory High visibility'
+      expect(page).not_to have_content 'The page you were looking for doesn\'t exist'
     end
   end
 end

--- a/spec/system/visibility_spec.rb
+++ b/spec/system/visibility_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe "View an Emory High Resolution Work", js: true do
+  context 'as a guest user' do
+    before do
+      solr = Blacklight.default_index.connection
+      solr.add([work_with_emory_high_visibility, work_with_open_visibility])
+      solr.commit
+    end
+
+    let(:emory_high_work_id) { '111-321' }
+    let(:open_work_id) { '222-321' }
+
+    let(:work_with_emory_high_visibility) do
+      {
+        id: emory_high_work_id,
+        has_model_ssim: ['CurateGenericWork'],
+        title_tesim: ['Work with Emory High visibility'],
+        edit_access_group_ssim: ["admin"],
+        read_access_group_ssim: ["registered"],
+        visibility_ssi: ['authenticated']
+      }
+    end
+
+    let(:work_with_open_visibility) do
+      {
+        id: open_work_id,
+        has_model_ssim: ['CurateGenericWork'],
+        title_tesim: ['Work with Open Access'],
+        edit_access_group_ssim: ["admin"],
+        read_access_group_ssim: ["public"]
+      }
+    end
+
+    let(:css_selector_for_uv) { '.uv-container' }
+
+    it 'only displays Universal Viewer if user has at least "read"-level access' do
+      # Should see Universal Viewer
+      visit solr_document_path(open_work_id)
+      expect(page).to have_selector(css_selector_for_uv)
+
+      # Shouldn't see Universal Viewer
+      visit solr_document_path(emory_high_work_id)
+      expect(page).to_not have_selector(css_selector_for_uv)
+    end
+  end
+  context 'as a logged in user' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      login_as user
+      solr = Blacklight.default_index.connection
+      solr.add([work_with_emory_high_visibility, work_with_open_visibility])
+      solr.commit
+    end
+
+    let(:emory_high_work_id) { '111-321' }
+    let(:open_work_id) { '222-321' }
+
+    let(:work_with_emory_high_visibility) do
+      {
+        id: emory_high_work_id,
+        has_model_ssim: ['CurateGenericWork'],
+        title_tesim: ['Work with Emory Low visibility'],
+        edit_access_group_ssim: ["admin"],
+        read_access_group_ssim: ["registered"],
+        visibility_ssi: ['authenticated']
+      }
+    end
+
+    let(:work_with_open_visibility) do
+      {
+        id: open_work_id,
+        has_model_ssim: ['CurateGenericWork'],
+        title_tesim: ['Work with Open Access'],
+        edit_access_group_ssim: ["admin"],
+        read_access_group_ssim: ["public"]
+      }
+    end
+
+    let(:css_selector_for_uv) { '.uv-container' }
+
+    it 'only displays Universal Viewer if user has at least "read"-level access' do
+      # Should see Universal Viewer
+      visit solr_document_path(open_work_id)
+      expect(page).to have_selector(css_selector_for_uv)
+
+      # Shouldn't see Universal Viewer
+      visit solr_document_path(emory_high_work_id)
+      expect(page).to have_selector(css_selector_for_uv)
+    end
+  end
+end

--- a/spec/system/visibility_spec.rb
+++ b/spec/system/visibility_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
+RSpec.describe "View a Work with Emory High Resolution visibility" do
   context 'as a guest user' do
     before do
       solr = Blacklight.default_index.connection
@@ -36,7 +36,7 @@ RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
 
     let(:css_selector_for_uv) { '.uv-container' }
 
-    it 'only displays Universal Viewer if user has at least "read"-level access' do
+    it 'only displays show page if user has at least "read"-level access' do
       # Should see Universal Viewer
       visit solr_document_path(open_work_id)
       expect(page).to have_content 'Work with Open Access'
@@ -81,9 +81,7 @@ RSpec.describe "View a Work with Emory High Resolution visibility", js: true do
       }
     end
 
-    let(:css_selector_for_uv) { '.uv-container' }
-
-    it 'only displays Universal Viewer if user has at least "read"-level access' do
+    it 'only displays show page if user has at least "read"-level access' do
       # Should see Universal Viewer
       visit solr_document_path(open_work_id)
       expect(page).to have_content 'Work with Open Access'


### PR DESCRIPTION
Currently search results show all Works and Collections, but if user is 
not logged in, restricted items go to 404 page, not show page.

Further work is needed to have search results reflect user's authorization

Logged in
![image](https://user-images.githubusercontent.com/45948126/73217617-432ff300-4126-11ea-9c0a-83cb85616f03.png)

Same page, not logged in
![image](https://user-images.githubusercontent.com/45948126/73217654-52af3c00-4126-11ea-9c31-7f8e737e6a2a.png)
