### PR TITLE
Add default sort behavior

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -469,10 +469,10 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, year_for_lux_isim desc, title_ssi asc', label: 'relevance'
-    config.add_sort_field 'year_for_lux_isim desc, title_ssi asc', label: 'year'
-    config.add_sort_field 'creator_ssi asc', label: 'creator'
-    config.add_sort_field 'title_ssi asc, year_for_lux_isim desc', label: 'title'
+    config.add_sort_field 'score desc, year_for_lux_isim desc, title_ssort asc', label: 'relevance'
+    config.add_sort_field 'year_for_lux_isim desc, title_ssort asc', label: 'year'
+    config.add_sort_field 'creator_ssort asc', label: 'creator'
+    config.add_sort_field 'title_ssort asc, year_for_lux_isim desc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -469,10 +469,10 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    # config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
-    # config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
-    # config.add_sort_field 'author_si asc, title_si asc', label: 'author'
-    # config.add_sort_field 'title_si asc, pub_date_si desc', label: 'title'
+    config.add_sort_field 'score desc, year_for_lux_isim desc, title_ssi asc', label: 'relevance'
+    config.add_sort_field 'year_for_lux_isim desc, title_ssi asc', label: 'year'
+    config.add_sort_field 'creator_ssi asc', label: 'creator'
+    config.add_sort_field 'title_ssi asc, year_for_lux_isim desc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,7 +1,11 @@
-<!-- [Blacklight Advanced Search overwrite] Remove unpopulated sort dropdown -->
+<div class="sort-buttons pull-left">
+  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
+  <%- sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
+  <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
+  <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+</div>
 
 <div class="submit-buttons pull-right">
-  <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
   <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary advanced-search-start-over" %>
   <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
 </div>

--- a/spec/system/sort_results_spec.rb
+++ b/spec/system/sort_results_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search the catalog', type: :system, js: false do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add([orange, banana, apple])
+    solr.commit
+  end
+
+  let(:orange) do
+    {
+      id: '111',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Orange Carrot'],
+      title_ssi: 'Orange Carrot',
+      year_for_lux_isim: [2000],
+      creator_ssi: 'Bittersweet Tangerine',
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:banana) do
+    {
+      id: '222',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Yellow Banana'],
+      title_ssi: 'Yellow Banana',
+      year_for_lux_isim: [2001],
+      creator_ssi: 'Buff Saffron',
+      visibility_ssi: ['open']
+    }
+  end
+
+  let(:apple) do
+    {
+      id: '333',
+      has_model_ssim: ['CurateGenericWork'],
+      title_tesim: ['Red Apple'],
+      title_ssi: 'Red Apple',
+      year_for_lux_isim: [2002],
+      creator_ssi: 'Sour Grapes',
+      visibility_ssi: ['open']
+    }
+  end
+
+  it 'has correct sorting behavior for year' do
+    visit '/?q=&search_field=common_fields&sort=year_for_lux_isim+desc%2C+title_ssi+asc'
+    expect(page).to have_content('1. Red Apple')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. Orange Carrot')
+  end
+
+  it 'has correct sorting behavior for creator' do
+    visit '/?q=&search_field=common_fields&sort=creator_ssi+asc'
+    expect(page).to have_content('1. Orange Carrot')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. Red Apple')
+  end
+
+  it 'has correct sorting behavior for title' do
+    visit '/?q=&search_field=common_fields&sort=title_ssi+asc%2C+year_for_lux_isim+desc'
+    expect(page).to have_content('1. Orange Carrot')
+    expect(page).to have_content('2. Red Apple')
+    expect(page).to have_content('3. Yellow Banana')
+  end
+end

--- a/spec/system/sort_results_spec.rb
+++ b/spec/system/sort_results_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       id: '111',
       has_model_ssim: ['CurateGenericWork'],
       title_tesim: ['Orange Carrot'],
-      title_ssi: 'Orange Carrot',
+      title_ssort: 'Orange Carrot',
       year_for_lux_isim: [2000],
-      creator_ssi: 'Bittersweet Tangerine',
+      creator_ssort: 'Bittersweet Tangerine',
       visibility_ssi: ['open']
     }
   end
@@ -27,9 +27,9 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       id: '222',
       has_model_ssim: ['CurateGenericWork'],
       title_tesim: ['Yellow Banana'],
-      title_ssi: 'Yellow Banana',
+      title_ssort: 'Yellow Banana',
       year_for_lux_isim: [2001],
-      creator_ssi: 'Buff Saffron',
+      creator_ssort: 'Buff Saffron',
       visibility_ssi: ['open']
     }
   end
@@ -38,32 +38,32 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     {
       id: '333',
       has_model_ssim: ['CurateGenericWork'],
-      title_tesim: ['Red Apple'],
-      title_ssi: 'Red Apple',
+      title_tesim: ['red Apple'],
+      title_ssort: 'red Apple',
       year_for_lux_isim: [2002],
-      creator_ssi: 'Sour Grapes',
+      creator_ssort: 'Sour Grapes',
       visibility_ssi: ['open']
     }
   end
 
   it 'has correct sorting behavior for year' do
-    visit '/?q=&search_field=common_fields&sort=year_for_lux_isim+desc%2C+title_ssi+asc'
-    expect(page).to have_content('1. Red Apple')
+    visit '/?q=&search_field=common_fields&sort=year_for_lux_isim+desc%2C+title_ssort+asc'
+    expect(page).to have_content('1. red Apple')
     expect(page).to have_content('2. Yellow Banana')
     expect(page).to have_content('3. Orange Carrot')
   end
 
   it 'has correct sorting behavior for creator' do
-    visit '/?q=&search_field=common_fields&sort=creator_ssi+asc'
+    visit '/?q=&search_field=common_fields&sort=creator_ssort+asc'
     expect(page).to have_content('1. Orange Carrot')
     expect(page).to have_content('2. Yellow Banana')
-    expect(page).to have_content('3. Red Apple')
+    expect(page).to have_content('3. red Apple')
   end
 
   it 'has correct sorting behavior for title' do
-    visit '/?q=&search_field=common_fields&sort=title_ssi+asc%2C+year_for_lux_isim+desc'
+    visit '/?q=&search_field=common_fields&sort=title_ssort+asc%2C+year_for_lux_isim+desc'
     expect(page).to have_content('1. Orange Carrot')
-    expect(page).to have_content('2. Red Apple')
+    expect(page).to have_content('2. red Apple')
     expect(page).to have_content('3. Yellow Banana')
   end
 end


### PR DESCRIPTION
- The default sort fields (relevance, year, creator, and title) are implemented using sortable fields added to Curate.
- Sorting works both in simple search and on the advanced search page.
- Once deployed, sorting by year should work immediately. Title and creator sorting should work once the respective sortable fields are re-indexed in Curate.