### PR TITLE
Add access group to search and facets for usability

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -121,6 +121,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_names_sim', limit: 5, label: 'Subject - Names'
     config.add_facet_field 'subject_geo_sim', limit: 5, label: 'Subject - Geographic Locations'
     config.add_facet_field 'human_readable_rights_statement_ssim', label: 'Rights Status'
+    config.add_facet_field 'read_access_group_ssim', label: 'Access Group'
 
     #config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     #config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
@@ -145,6 +146,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'creator_tesim', label: 'Creator'
     config.add_index_field 'human_readable_date_created_tesim', label: 'Date'
     config.add_index_field 'human_readable_content_type_tesim', label: 'Format'
+    config.add_index_field 'read_access_group_ssim', label: 'Access Group'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe CatalogController, type: :controller do
        'subject_topics',
        'subject_names',
        'subject_geo',
-       'human_readable_rights_statement']
+       'human_readable_rights_statement',
+       'read_access_group']
     end
 
     it 'has exactly expected facets' do
@@ -40,7 +41,8 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_index_fields) do
       ['creator_tesim',
        'human_readable_date_created_tesim',
-       'human_readable_content_type_tesim']
+       'human_readable_content_type_tesim',
+       'read_access_group']
     end
     it { expect(index_fields).to contain_exactly(*expected_index_fields) }
   end


### PR DESCRIPTION
Initial addition of "Access Group" to search results and facets to facilitate testing and continued feedback.

![image](https://user-images.githubusercontent.com/45948126/73547361-c1351800-440c-11ea-8c06-00a86b386797.png)
![image](https://user-images.githubusercontent.com/45948126/73547387-cdb97080-440c-11ea-8876-62176fd3e2a7.png)
