### PR TITLE
Gems for OpenSSH key support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ end
 ruby '>=2.5.0'
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# Needed for support of OpenSSH keys
+gem 'bcrypt_pbkdf'
 # Blacklight 7, because Blacklight 6 did not successfully deploy to production
 gem 'blacklight', ">= 7"
 gem 'blacklight-access_controls', git: 'https://github.com/projectblacklight/blacklight-access_controls', ref: '21e04f5'
@@ -20,6 +21,8 @@ gem 'bootstrap', '~> 4.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'
 gem 'dotenv-rails'
+# Needed for support of OpenSSH keys
+gem 'ed25519'
 gem 'honeybadger', '~> 4.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -885,6 +885,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
+    bcrypt_pbkdf (1.0.1)
     bindex (0.8.1)
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
@@ -977,6 +978,7 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    ed25519 (1.2.4)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -1266,6 +1268,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf
   bixby
   blacklight (>= 7)
   blacklight-access_controls!
@@ -1287,6 +1290,7 @@ DEPENDENCIES
   coveralls
   devise
   dotenv-rails
+  ed25519
   factory_bot_rails (~> 4.11.1)
   ffaker
   honeybadger (~> 4.0)


### PR DESCRIPTION
Cannot deploy to servers, OpenSSH keys need these additional gems for support.