### PR TITLE
Update hierarchical work show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -224,6 +224,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'member_of_collection_ids_ssim'
     # For "View items in this digital collection" section of show page
     config.add_show_field 'title_tesim'
+    # For "This item contains:" section of show page
+    config.add_show_field 'child_works_for_lux_tesim'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/presenters/this_item_contains_presenter.rb
+++ b/app/presenters/this_item_contains_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ThisItemContainsPresenter
+  attr_reader :document
+
+  def initialize(document:)
+    @document = document
+  end
+
+  def children
+    return nil unless @document["child_works_for_lux_tesim"]
+    @document["child_works_for_lux_tesim"].map do |w|
+      parts = w.split(", ", 3)
+      { id: parts[0], thumbnail_path: parts[1], title: parts[2] }
+    end
+  end
+end

--- a/app/views/catalog/_metadata_col_2.html.erb
+++ b/app/views/catalog/_metadata_col_2.html.erb
@@ -3,6 +3,9 @@
     <%= render "about_this_collection", document: document %>
   <% end %>
   <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
+    <%= render "this_item_contains", document: document %>
+  <% end %>
+  <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
     <%= render "about_this_item", document: document %>
   <% end %>
   <%= render "subjects_keywords", document: document %>

--- a/app/views/catalog/_this_item_contains.html.erb
+++ b/app/views/catalog/_this_item_contains.html.erb
@@ -1,0 +1,1 @@
+<%= render 'this_item_contains_block', document: document, presenter: ThisItemContainsPresenter, presenter_class: 'this-item-contains', title: 'This item contains:' %>

--- a/app/views/catalog/_this_item_contains_block.html.erb
+++ b/app/views/catalog/_this_item_contains_block.html.erb
@@ -1,0 +1,14 @@
+<% child_works = presenter.new(document: document).children %>
+<% if child_works %>
+  <div class="<%= presenter_class %> card mb-2">
+    <div class="card-header">This item contains:</div>
+    <div class="card-body">
+      <dl class="row">
+      <% child_works.each do |w| %>
+        <dt class="col-sm-3"><img class="img-fluid" src=<%= w[:thumbnail_path] %>%></dt>
+        <dd class="col-sm-9"><a href=<%= w[:id] %>><%= w[:title] %></a></dd>
+      <% end %>
+      </dl>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:read, document) %>
+<% if can?(:read, document) && !document["child_works_for_lux_tesim"] %>
   <div class="uv-container">
     <iframe
         class="universal-viewer-iframe"

--- a/spec/presenters/this_item_contains_presenter_spec.rb
+++ b/spec/presenters/this_item_contains_presenter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ThisItemContainsPresenter do
+  let(:contains_children) do
+    { "child_works_for_lux_tesim" =>
+      ["111, /fake/thumbnail/path/1, First Child",
+       "222, /fake/thumbnail/path/2, Second Child",
+       "333, /fake/thumbnail/path/3, Third Child"] }
+  end
+  let(:pres) { described_class.new(document: contains_children) }
+  context 'with a solr document' do
+    describe '#children' do
+      it 'has the correct children' do
+        expect(pres.children).to eq(
+          [{ id: "111", thumbnail_path: "/fake/thumbnail/path/1", title: "First Child" },
+           { id: "222", thumbnail_path: "/fake/thumbnail/path/2", title: "Second Child" },
+           { id: "333", thumbnail_path: "/fake/thumbnail/path/3", title: "Third Child" }]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Hierarchical works (i.e., CurateGenericWorks that have CurateGenericWorks as children) now display their child works in a partial on the show page
- The show page for hierarchical works suppresses the Universal Viewer