### PR TITLE
Removes 'About the item' tab from more info tab

### DIFF
--- a/app/values/uv_configuration.rb
+++ b/app/values/uv_configuration.rb
@@ -20,6 +20,11 @@ class UvConfiguration < ActiveSupport::HashWithIndifferentAccess
           "options" => {
             "pagingToggleEnabled" => true
           }
+        },
+        "moreInfoRightPanel" => {
+          "content" => {
+            "manifestHeader" => nil
+          }
         }
       }
     }

--- a/spec/values/uv_configuration_spec.rb
+++ b/spec/values/uv_configuration_spec.rb
@@ -11,6 +11,9 @@ describe UvConfiguration do
         "shareEnabled" => false,
         "downloadEnabled" => false
       )
+      expect(described_class.default_values["modules"]["moreInfoRightPanel"]["content"]).to include(
+        "manifestHeader" => nil
+      )
     end
   end
 


### PR DESCRIPTION
* We are removing `About the item` text that appears in the more info tab.

Before:
![image](https://user-images.githubusercontent.com/17075287/75492229-546a5a80-5985-11ea-98b8-585c4c47bf41.png)

After:
![image](https://user-images.githubusercontent.com/17075287/75492244-63510d00-5985-11ea-9d7f-8356c07a7aec.png)

Connected to emory-libraries/dlp-curate#988