### PR TITLE
Search box styling

### DIFF
--- a/app/assets/stylesheets/lux/_search_form.scss
+++ b/app/assets/stylesheets/lux/_search_form.scss
@@ -1,6 +1,9 @@
 // bootstrap does flex-grow: 1 by default which makes the
 // text input roughly the same size as the select in many cases
 .input-group {
+  &.col-md-12 {
+    padding-right: 0;
+  }
   > .form-control,
   > .custom-select {
     width: fit-content;
@@ -15,5 +18,14 @@
     &.search-q {
       flex-grow: 3;
     }
+  }
+}
+
+.form-inline {
+  &.col-lg-7,
+  &.col-md-12,
+  &.col-sm-12,
+  {
+    padding-right: 0;
   }
 }

--- a/app/assets/stylesheets/lux/_search_form.scss
+++ b/app/assets/stylesheets/lux/_search_form.scss
@@ -1,10 +1,19 @@
 // bootstrap does flex-grow: 1 by default which makes the
 // text input roughly the same size as the select in many cases
-.input-group > .form-control {
-  &.search-q {
-    flex-grow: 3;
+.input-group {
+  > .form-control,
+  > .custom-select {
+    width: fit-content;
   }
-  &.search_field {
-    flex-grow: 3;
+  > .custom-select {
+    &.search-field {
+      flex-grow: 1;
+      max-width: fit-content;
+    }
+  }
+  > .form-control {
+    &.search-q {
+      flex-grow: 3;
+    }
   }
 }

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -110,3 +110,4 @@ $btn-font-weight:                    $font-weight-bold;
 
 //Custom select - search form
 $custom-select-color:                $charcoal;
+$input-line-height:                     2.375;

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only sr-only-focusable"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
-  <div class="input-group">
+  <div class="input-group col-md-12">
     <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
                        options_for_select(search_fields, h(params[:search_field])),

--- a/app/views/shared/_big_nav.html.erb
+++ b/app/views/shared/_big_nav.html.erb
@@ -23,7 +23,7 @@
   <span class="navbar-toggler-icon"></span>
 </button>
 <!-- Don't show regular search on advanced search page -->
-<form class="form-inline my-2 my-lg-0" id="search-form">
+<form class="form-inline col-md-8 my-2 my-lg-0" id="search-form">
   <% unless request.original_fullpath == "/advanced" %>
     <%= render_search_bar %>
   <% end %>

--- a/app/views/shared/_big_nav.html.erb
+++ b/app/views/shared/_big_nav.html.erb
@@ -17,13 +17,11 @@
     </div>
   </div>
 </div>
-
-
 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
   <span class="navbar-toggler-icon"></span>
 </button>
 <!-- Don't show regular search on advanced search page -->
-<form class="form-inline col-md-8 my-2 my-lg-0" id="search-form">
+<form class="form-inline col-lg-7 col-md-12 col-sm-12 my-2 my-lg-0" id="search-form">
   <% unless request.original_fullpath == "/advanced" %>
     <%= render_search_bar %>
   <% end %>


### PR DESCRIPTION
Search box takes up greater proportion of navigation, align right, make drop-down text full size until small sizes, text entry box takes up most of real estate as element gets smaller.