### PR TITLE
Fixes the search issue by removing redundant tag.

### DIFF
--- a/app/views/shared/_big_nav.html.erb
+++ b/app/views/shared/_big_nav.html.erb
@@ -21,8 +21,8 @@
   <span class="navbar-toggler-icon"></span>
 </button>
 <!-- Don't show regular search on advanced search page -->
-<form class="form-inline col-lg-7 col-md-12 col-sm-12 my-2 my-lg-0" id="search-form">
+<div class="form-inline col-lg-7 col-md-12 col-sm-12 my-2 my-lg-0" id="search-form">
   <% unless request.original_fullpath == "/advanced" %>
     <%= render_search_bar %>
   <% end %>
-</form>
+</div>

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 include Warden::Test::Helpers
-OmniAuth.config.test_mode = true
 
 RSpec.describe 'Search the catalog', type: :system, js: false do
   before do
@@ -166,19 +165,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     }
   end
 
-  let(:auth_hash) do
-    OmniAuth.config.mock_auth[:shibboleth] = OmniAuth::AuthHash.new(
-      provider: 'shibboleth',
-      uid: "janeq",
-      info: {
-        display_name: "Jane Quest",
-        uid: 'janeq',
-        mail: 'janeq@emory.edu'
-      }
-    )
-  end
-
-  let(:user) { User.from_omniauth(auth_hash) }
+  let(:user) { FactoryBot.create(:user) }
 
   it 'gets correct search results' do
     visit root_path

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+include Warden::Test::Helpers
+OmniAuth.config.test_mode = true
 
 RSpec.describe 'Search the catalog', type: :system, js: false do
   before do
@@ -20,6 +22,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
               publisher,
               creator_of_collection])
     solr.commit
+    login_as(user)
   end
 
   let(:orange) do
@@ -163,6 +166,20 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     }
   end
 
+  let(:auth_hash) do
+    OmniAuth.config.mock_auth[:shibboleth] = OmniAuth::AuthHash.new(
+      provider: 'shibboleth',
+      uid: "janeq",
+      info: {
+        display_name: "Jane Quest",
+        uid: 'janeq',
+        mail: 'janeq@emory.edu'
+      }
+    )
+  end
+
+  let(:user) { User.from_omniauth(auth_hash) }
+
   it 'gets correct search results' do
     visit root_path
     # Search for something
@@ -216,6 +233,56 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
         'Target in uniform title',
         'Target in creator, model is collection'
       )
+    end
+  end
+
+  it 'performs searches from about page' do
+    visit "/about"
+    fill_in 'q', with: '222'
+    click_on 'search'
+
+    within 'span.page-entries' do
+      expect(page).to have_content('1 entry found')
+    end
+  end
+
+  it 'performs searches from copyright-reuse page' do
+    visit "/copyright-reuse"
+    fill_in 'q', with: '222'
+    click_on 'search'
+
+    within 'span.page-entries' do
+      expect(page).to have_content('1 entry found')
+    end
+  end
+
+  it 'performs searches from contact page' do
+    visit "/contact"
+    fill_in 'q', with: '222'
+    click_on 'search'
+
+    within 'span.page-entries' do
+      expect(page).to have_content('1 entry found')
+    end
+  end
+
+  it 'performs searches from bookmarks page' do
+    visit "/bookmarks"
+    fill_in 'q', with: '222'
+    click_on 'search'
+
+    within 'span.page-entries' do
+      expect(page).to have_content('1 entry found')
+    end
+  end
+
+  it 'performs searches from search_history page' do
+    visit "/search_history"
+    fill_in 'q', with: '222'
+    click_on 'search'
+
+    within 'span.page-entries' do
+      expect(page).to have_content('1 entry found')
     end
   end
 end


### PR DESCRIPTION
1. _big_nav.html.erb: form action in search form partial wasn't working correctly
due to big nav partial wrapping that partial in another form tag. Rails got confused
and cancelled out the second form tag's action.