### PR TITLE
X forwarded for

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,10 +69,7 @@ class ApplicationController < ActionController::Base
     end
 
     def user_ip
-      if request.headers["X-Forwarded-For"]
-        request.headers["X-Forwarded-For"]
-      elsif request.headers["REMOTE_ADDR"]
-        request.headers["REMOTE_ADDR"]
-      end
+      return request.headers["X-Forwarded-For"] if request.headers["X-Forwarded-For"]
+      return request.headers["REMOTE_ADDR"] if request.headers["REMOTE_ADDR"]
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,14 @@ class ApplicationController < ActionController::Base
   private
 
     def current_ability
-      @current_ability ||= Ability.new(current_user, request.headers["REMOTE_ADDR"])
+      @current_ability ||= Ability.new(current_user, user_ip)
+    end
+
+    def user_ip
+      if request.headers["X-Forwarded-For"]
+        request.headers["X-Forwarded-For"]
+      elsif request.headers["REMOTE_ADDR"]
+        request.headers["REMOTE_ADDR"]
+      end
     end
 end

--- a/spec/requests/visibility_request_spec.rb
+++ b/spec/requests/visibility_request_spec.rb
@@ -139,12 +139,12 @@ RSpec.describe "Visibility requests", :clean, type: :request do
         expect(response.content_type).to eq "text/html"
       end
 
-      it "does not load the 'show' page for a work with 'Rose High View' visibility" do
+      it "does not load the 'show' page for a work with 'Rose High View' visibility using remote address" do
         get "/catalog/#{rose_high_work_id}", headers: { "REMOTE_ADDR": non_reading_room_ip }
         expect(response.status).to eq 404
       end
 
-      it "does not load the 'show' page for a work with 'Rose High View' visibility" do
+      it "does not load the 'show' page for a work with 'Rose High View' visibility using x-forwarded-for" do
         get "/catalog/#{rose_high_work_id}", headers: { "X-Forwarded-For": non_reading_room_ip }
         expect(response.status).to eq 404
       end

--- a/spec/requests/visibility_request_spec.rb
+++ b/spec/requests/visibility_request_spec.rb
@@ -140,7 +140,12 @@ RSpec.describe "Visibility requests", :clean, type: :request do
       end
 
       it "does not load the 'show' page for a work with 'Rose High View' visibility" do
-        get "/catalog/#{rose_high_work_id}"
+        get "/catalog/#{rose_high_work_id}", headers: { "REMOTE_ADDR": non_reading_room_ip }
+        expect(response.status).to eq 404
+      end
+
+      it "does not load the 'show' page for a work with 'Rose High View' visibility" do
+        get "/catalog/#{rose_high_work_id}", headers: { "X-Forwarded-For": non_reading_room_ip }
         expect(response.status).to eq 404
       end
 
@@ -152,10 +157,17 @@ RSpec.describe "Visibility requests", :clean, type: :request do
     end
 
     context "when in the Rose Reading Room" do
-      it "loads the 'show' page for a work with 'Rose High View' visibility" do
+      it "loads the 'show' page for a work with 'Rose High View' visibility using Remote Address header" do
         get("/catalog/#{rose_high_work_id}", headers: { "REMOTE_ADDR": reading_room_ip })
 
         expect(request.headers["REMOTE_ADDR"]).to eq reading_room_ip
+        expect(response.status).to eq 200
+      end
+
+      it "loads the 'show' page for a work with 'Rose High View' visibility using X-Forwarded-For header" do
+        get("/catalog/#{rose_high_work_id}", headers: { "X-Forwarded-For": reading_room_ip })
+
+        expect(request.headers["X-Forwarded-For"]).to eq reading_room_ip
         expect(response.status).to eq 200
       end
     end


### PR DESCRIPTION
Per Emory middleware, need to include X-Forwarded-For headers to capture user's IP address for "Rose High View" IP restrictions, rather than the Load Balancer's IP address.