### PR TITLE
Use http password protection to prevent crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ URL for the Hyrax instance that serves the Work's IIIF manifest. An example:
 `https://curate-qa.curationexperts.com/concern/curate_generic_works/`.
 1. The `THUMBNAIL_URL` environment variable needs to be set. This URL is the base URL for the Hyrax instance that serves the Work's thumbnail images. An example: `https://curate-qa.curationexperts.com`
 
+## HTTP Password protection in production mode
+In order to prevent search engine crawling of the system before it's ready to launch, we use HTTP password protection. This is set via environment variables.
+It is enabled by default. Set `HTTP_PASSWORD_PROTECT='false'` to disable this feature.
+Set the login and password via environment variables `HTTP_USERNAME` and `HTTP_PASSWORD`
+
 ## Loading sample data
 
 In order to have a local solr instance with data in it, run this rake task:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ URL for the Hyrax instance that serves the Work's IIIF manifest. An example:
 
 ## HTTP Password protection in production mode
 In order to prevent search engine crawling of the system before it's ready to launch, we use HTTP password protection. This is set via environment variables.
-It is enabled by default. Set `HTTP_PASSWORD_PROTECT='false'` to disable this feature.
+Set `HTTP_PASSWORD_PROTECT='true'` to enable this feature.
+Set `HTTP_PASSWORD_PROTECT='false'` to disable this feature.
 Set the login and password via environment variables `HTTP_USERNAME` and `HTTP_PASSWORD`
 
 ## Loading sample data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@
 class ApplicationController < ActionController::Base
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
+  include HttpAuthConcern
+
   layout :determine_layout if respond_to? :layout
 
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/http_auth_concern.rb
+++ b/app/controllers/concerns/http_auth_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module HttpAuthConcern
+  extend ActiveSupport::Concern
+  included do
+    before_action :http_authenticate
+  end
+  def http_authenticate
+    # Disable http password protection by setting HTTP_PASSWORD_PROTECT = 'false'
+    return true unless ENV['HTTP_PASSWORD_PROTECT'] == 'true'
+
+    http_username = ENV['HTTP_USERNAME'] || 'admin'
+    http_password = ENV['HTTP_PASSWORD'] || 'changeme'
+    authenticate_or_request_with_http_basic do |username, password|
+      username == http_username && password == http_password
+    end
+  end
+end

--- a/spec/system/password_protect_spec.rb
+++ b/spec/system/password_protect_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Password protect non production instances', type: :system do
+  context 'visiting an instance when HTTP_PASSWORD_PROTECT is false' do
+    before do
+      ENV['HTTP_PASSWORD_PROTECT'] = 'false'
+    end
+    it 'does not prompt the user for a password' do
+      visit('/')
+      expect(page).to have_content('Emory')
+    end
+  end
+
+  context 'visiting an instance when HTTP_PASSWORD_PROTECT is true' do
+    before do
+      ENV['HTTP_PASSWORD_PROTECT'] = 'true'
+    end
+    after do
+      ENV['HTTP_PASSWORD_PROTECT'] = 'false'
+    end
+    it 'prompts the user for a password' do
+      visit('/')
+      expect(page.find(:xpath, '//body').text).to eq "HTTP Basic: Access denied."
+    end
+  end
+end


### PR DESCRIPTION
This will let us set up http password protection via environment variables, so it can easily be switched on and off.

Set `HTTP_PASSWORD_PROTECT='true'` in `.env.production` to enable password protection.
Login and password values are set via `HTTP_USERNAME` and `HTTP_PASSWORD`