### PR TITLE
Adds the branding banner that is set in curate to the collection show page when it exists.

### DIFF
--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,4 +1,9 @@
-<% if document["child_works_for_lux_tesim"] || document["has_model_ssim"] == ["Collection"]  %>
+<% 
+  if document["child_works_for_lux_tesim"] || 
+    (document["has_model_ssim"] == ["Collection"] && document["banner_path_ss"].nil?) 
+%>
+<% elsif document["has_model_ssim"] == ["Collection"] && document["banner_path_ss"].present? %>
+  <img src=<%= (ENV['THUMBNAIL_URL'] || '') + document["banner_path_ss"] %> class="img-fluid" id="collection-banner">
 <% else %>
   <%= render "uv", document: document %>
 <% end %>

--- a/spec/system/view_collection_spec.rb
+++ b/spec/system/view_collection_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe "View a Collection", type: :system, js: false do
   it 'has Collection specific metadata values' do
     expect(page).to have_content('Chester W. Topp collection of Victorian yellowbacks and paperbacks')
   end
+
+  it 'lacks a banner when banner_path_ss is nil' do
+    expect(page).not_to have_selector("#collection-banner")
+  end
+
+  context 'with banner' do
+    let(:work_attributes) do
+      COLLECTION.merge(banner_path_ss: '/branding/119f4qrfj9-cor/banner/banner.jpg')
+    end
+
+    it 'processes an img tag with the right id' do
+      expect(page.find('#collection-banner')['src']).to match(/banner.jpg/)
+    end
+  end
 end


### PR DESCRIPTION
1. _show.html.erb: broadens the logic of what is seen when
   document is a Collection and banner path is passed through.
   Also creates an image tag with unique id.
2. view_collection_spec.rb: inserts tests for banner delivery.