### PR TITLE
Edits download options text for emory_low_download works

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
              elsif v == "authenticated" && user_signed_in?
                uv_config_liberal
              elsif v == "emory_low" && user_signed_in?
-               uv_config_liberal
+               uv_config_liberal_low
              else
                default_config
              end
@@ -58,6 +58,32 @@ class ApplicationController < ActionController::Base
       }
     )
   end
+
+  # Construct a UV configuration for emory_low visibility with downloads and share enabled,
+  # and download dialogue options/content modifications
+  # @return [UvConfiguration]
+  def uv_config_liberal_low # rubocop:disable Metrics/MethodLength
+    UvConfiguration.new(
+      modules: {
+        footerPanel: {
+          options: {
+            shareEnabled: true,
+            downloadEnabled: true,
+            fullscreenEnabled: true
+          }
+        },
+        downloadDialogue: {
+          options: {
+            currentViewDisabledPercentage: 0, # set to an unreasonably low value so that Current View option is hidden
+            confinedImageSize: 100_000 # set to an unreasonably high value so that Whole Image Low Res option is hidden
+          },
+          content: {
+            wholeImageHighRes: "Whole Image 400px"
+          }
+        }
+      }
+    )
+  end # rubocop:enable Metrics/MethodLength
 
   def visibility_lookup(resource_id)
     response = Blacklight.default_index.connection.get 'select', params: { q: "id:#{resource_id}" }

--- a/spec/requests/uv_config_spec.rb
+++ b/spec/requests/uv_config_spec.rb
@@ -173,6 +173,12 @@ RSpec.describe "UvConfiguration requests", :clean, type: :request do
           "downloadEnabled" => true,
           "fullscreenEnabled" => true
         )
+        expect(response_values["modules"]["downloadDialogue"]).to include("options", "content")
+        expect(response_values["modules"]["downloadDialogue"]["options"]).to include(
+          "currentViewDisabledPercentage" => 0,
+          "confinedImageSize" => 100_000
+        )
+        expect(response_values["modules"]["downloadDialogue"]["content"]).to include("wholeImageHighRes")
       end
     end
   end


### PR DESCRIPTION
* Emory Low Download works have a download specification that makes sure the height of the image being downloaded is always restricted to 400px. In this commit, we change the options (text) that show up in the download dialogue so we can see only one option which is whole image limited to 400px.

Before:
![image](https://user-images.githubusercontent.com/17075287/77697178-c03fe300-6f84-11ea-84b1-68982c267c7b.png)

After:
![image](https://user-images.githubusercontent.com/17075287/77697187-c59d2d80-6f84-11ea-8bef-3c2c716b98cc.png)

* Download options:
  * `currentViewDisabledPercentage` is set to 0, because the width and the height of the actual image will always be greater, and this will hide the current view download button (refer: https://github.com/UniversalViewer/universalviewer/blob/2a08b8aa87dce7dd5d4d6c65c63df495bebe9775/src/extensions/uv-seadragon-extension/DownloadDialogue.ts#L383)
  * `confinedImageSize` is set to a high width because the Whole Image Low Res option will be hidden as long as the width of the actual image is lesser than the `confinedImageSize` option (refer: https://github.com/UniversalViewer/universalviewer/blob/2a08b8aa87dce7dd5d4d6c65c63df495bebe9775/src/extensions/uv-seadragon-extension/DownloadDialogue.ts#L611)

Connected to emory-libraries/dlp-curate#1054