### PR TITLE
Style facets

### DIFF
--- a/app/assets/stylesheets/lux.scss
+++ b/app/assets/stylesheets/lux.scss
@@ -1,5 +1,4 @@
 @import url(https://fonts.googleapis.com/css?family=Cardo:400,700|Open+Sans:400,700&display=swap);
-@import 'lux/buttons';
 @import 'lux/cards';
 @import 'lux/colors';
 @import 'lux/facets';

--- a/app/assets/stylesheets/lux/_buttons.scss
+++ b/app/assets/stylesheets/lux/_buttons.scss
@@ -1,6 +1,0 @@
-@import 'lux/variables';
-
-.btn {
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}

--- a/app/assets/stylesheets/lux/_cards.scss
+++ b/app/assets/stylesheets/lux/_cards.scss
@@ -1,7 +1,9 @@
 @import "lux/variables";
 
-.card-header {
+div.card-header {
   font-weight: $font-weight-bold;
   text-transform: uppercase;
   font-size: $font-size-sm;
+  background-color: $dark-blue;
+  color: $gold;
 }

--- a/app/assets/stylesheets/lux/_colors.scss
+++ b/app/assets/stylesheets/lux/_colors.scss
@@ -6,6 +6,7 @@ $dark-blue: #091C44;
 $base-blue: #082B73;
 $mid-blue: #004990;
 $bright-blue: #336BE6;
+$alt-bright-blue: #5387F7;
 $light-blue: #D0DEFD;
 
 $gold: #E9BF55;
@@ -20,7 +21,7 @@ $white: #FFFFFF;
 $red:     #B82216;
 $orange:  #AB750C;
 $yellow:  #F6E4C1;
-$green:   #257611;
+$green:   #28A745;
 
 $colors: ();
 // stylelint-disable-next-line scss/dollar-variable-default

--- a/app/assets/stylesheets/lux/_facets.scss
+++ b/app/assets/stylesheets/lux/_facets.scss
@@ -1,6 +1,125 @@
+// The following rules are selectively brought in
+// and adapted from Blacklight's _facets.scss
+
 @media (min-width: 992px) {
   .facets-toggleable-md .facets-collapse {
     display: block !important;
     width: 100%;
+  }
+}
+
+.facets-heading {
+  font-size: $facets-heading-font-size;
+}
+
+.facets > .navbar {
+  padding: 0;
+  margin-bottom: $facets-heading-margin-y;
+}
+
+.facet-limit {
+  margin-bottom: $spacer;
+}
+
+.facet-limit-active {
+  @extend .border-success;
+
+  .card-header {
+    @extend .bg-success;
+  }
+}
+
+.facet-field-heading > .btn {
+  line-height: $facet-line-height;
+  color: #212529;
+}
+
+.facet-values {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+  margin-bottom: 0;
+
+  li {
+
+    display: table-row;
+    .selected {
+      @extend .text-success;
+      font-weight: $font-weight-bold;
+
+      &.facet-count {
+        font-weight: $font-weight-normal;
+      }
+    }
+
+  }
+
+  @mixin hyphens-auto {
+    overflow-wrap: break-word;
+    -webkit-hyphens: auto;
+    -o-hyphens: auto;
+    hyphens: auto;
+  }
+
+  .facet-label {
+    display: table-cell;
+    padding-right: 1em;
+    text-indent: -$spacer;
+    padding-left: $spacer;
+    padding-bottom: $spacer / 2;
+    @include hyphens-auto;
+
+    a {
+      font-weight: $font-weight-bold;
+      color: $alt-bright-blue;
+
+      &.remove {
+        color: $charcoal;
+        font-weight: $font-weight-bold;
+        padding-left: $spacer / 2;
+        text-decoration: none;
+      }
+    }
+  }
+
+  .facet-count {
+    display: table-cell;
+    vertical-align: top;
+    text-align: right;
+    width: 5em;
+  }
+}
+
+.facet-extended-list {
+  .sort-options {
+    text-align:right;
+  }
+
+  .prev-next-links {
+    float:left;
+  }
+}
+
+// The following rules are selectively brought in
+// and adapted from Blacklight's _bootstrap_overrides.scss
+
+.facet-field-heading {
+  border-bottom: 0;
+  
+  button {
+    &::after {
+      content: "❯";
+      float: right;
+      transform: rotate(90deg);
+    }
+
+    &.collapsed {
+      border-bottom: 0;
+
+      &::after {
+        transform: rotate(0deg);
+        transition: transform 0.1s ease;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/lux/_search_form.scss
+++ b/app/assets/stylesheets/lux/_search_form.scss
@@ -34,7 +34,7 @@ form.search-query-form {
     }
 
     &.search-q:focus {
-      border-color: #5387F7;
+      border-color: $alt-bright-blue;
     }
   }
 }
@@ -53,11 +53,16 @@ button#search {
   width: $search-form-button-width;
   padding: 0 $search-form-button-padding-x;
   border: 1px solid $bright-blue;
-}
 
-button#search:hover {
-  border-color: $mid-blue;
-  background-color: $mid-blue;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-bold;
+
+  &:hover {
+    border-color: $mid-blue;
+    background-color: $mid-blue;
+  }
 }
 
 .navbar-toggler {

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -116,6 +116,13 @@ $hero-title-font-size-large:          $font-size-base * 3.125;
 $hero-image-height:                   15rem;
 $hero-image-height-large:             27.5rem;
 
+// Facets
+
+$facets-heading-font-size:    $font-size-base * 1.5;
+$facets-heading-margin-y:    1.125rem;
+
+$facet-line-height:           1.5rem;
+
 
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15%;
@@ -125,10 +132,6 @@ $border-radius-lg:            0.3rem;
 $border-radius-sm:            0.2rem;
 $border-radius-xs:            0.125rem;
 
-// Card
-$card-cap-bg:                       $dark-blue;
-$card-cap-color:                    $gold;
-
 // Buttons + Forms
 //
 // Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
@@ -137,7 +140,3 @@ $input-btn-line-height:             $line-height-base * 1.2;
 
 // Form
 $input-border-color:                $base-slate;
-
-// Button
-$btn-font-size:                      $font-size-sm;
-$btn-font-weight:                    $font-weight-bold;

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -8,6 +8,8 @@ en:
       bookmarks: 'Bookmarks'
       search_history: 'History'
     search:
+      facets:
+        title: 'Browse All Items'
       form:
         search:
           placeholder: 'Search Digital Collections'


### PR DESCRIPTION
- Default Blacklight styles are selectively brought in and adapted for Lux facets
- Lux's default green is changed to Blacklight's default green in order to have acceptable color contrast on active facet elements
- Generic button rules from `_variables.scss` are removed and applied more selectively to the search form button
- Generic card rules from `_variables.scss` and `_buttons.scss` are removed and applied more selectively to cards on the show page so as not to override the facet styling