### PR TITLE
Explore collections fix

### DIFF
--- a/config/explore_collections.yml
+++ b/config/explore_collections.yml
@@ -1,13 +1,13 @@
 collections:
   - title: Health Sciences Center Library Artifact Collection
     image: explore-collections-medical.jpg
-    path: /
+    path: https://digital.library.emory.edu/catalog/914nk98sfv-cor
     description: Contains a wide selection of medical instruments including surgical instruments, physician's medicine bags, scales, tourniquets, scarifier sets, and other instruments dating from 1832 to 2000.
   - title: Robert Langmuir African American Photograph Collection
     image: explore-collections-langmuir.jpg
-    path: /
+    path: https://digital.library.emory.edu/catalog/320sqv9s4v-cor
     description: Collection of photographs depicting African American life and culture collected by Robert Langmuir.
   - title: Oxford College Collection of Asian Artifacts
     image: explore-collections-kobe.jpg
-    path: /
+    path: https://digital.library.emory.edu/catalog/5053ffbg7n-cor
     description: Contains a variety of Japanese, Korean, and Chinese artifacts, most of them purchased in Kobe, Japan by William Patillo Turner while he was a member of the Japan Mission of the United Methodist Church, South.

--- a/config/explore_collections.yml
+++ b/config/explore_collections.yml
@@ -1,13 +1,13 @@
 collections:
   - title: Health Sciences Center Library Artifact Collection
     image: explore-collections-medical.jpg
-    path: https://digital.library.emory.edu/catalog/914nk98sfv-cor
+    path: https://digital.library.emory.edu/catalog/5053ffbg7n-cor
     description: Contains a wide selection of medical instruments including surgical instruments, physician's medicine bags, scales, tourniquets, scarifier sets, and other instruments dating from 1832 to 2000.
   - title: Robert Langmuir African American Photograph Collection
     image: explore-collections-langmuir.jpg
-    path: https://digital.library.emory.edu/catalog/320sqv9s4v-cor
+    path: https://digital.library.emory.edu/catalog/914nk98sfv-cor
     description: Collection of photographs depicting African American life and culture collected by Robert Langmuir.
   - title: Oxford College Collection of Asian Artifacts
     image: explore-collections-kobe.jpg
-    path: https://digital.library.emory.edu/catalog/5053ffbg7n-cor
+    path: https://digital.library.emory.edu/catalog/320sqv9s4v-cor
     description: Contains a variety of Japanese, Korean, and Chinese artifacts, most of them purchased in Kobe, Japan by William Patillo Turner while he was a member of the Japan Mission of the United Methodist Church, South.


### PR DESCRIPTION
- Because the IDs of these objects are different in each environment, each link is hard-coded for production