### PR TITLE
Style advanced search page

### DIFF
--- a/app/assets/stylesheets/lux.scss
+++ b/app/assets/stylesheets/lux.scss
@@ -1,4 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Cardo:400,700|Open+Sans:400,700&display=swap);
+@import 'lux/advanced_search';
 @import 'lux/breadcrumbs';
 @import 'lux/cards';
 @import 'lux/collection_image';

--- a/app/assets/stylesheets/lux/_advanced_search.scss
+++ b/app/assets/stylesheets/lux/_advanced_search.scss
@@ -1,0 +1,42 @@
+@import 'variables';
+
+.advanced-search-start-over {
+  border: 1px solid $charcoal;
+  font: normal bold $font-size-sm $font-family-sans-serif;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: $white;
+  background-color: $charcoal;
+  transition: $link-hover-transition;
+  padding: $advanced-search-button-padding;
+  height: $advanced-search-button-height;
+
+  &:hover {
+    color: $charcoal;
+    background-color: $white;
+    text-decoration: none;
+  }
+}
+
+.query-criteria-heading {
+  font-size:   $advanced-search-subtitle-font-size;
+}
+
+.form-control {
+  height: $search-form-height;
+  margin-right: $search-form-margin-x;
+  padding: $search-form-q-padding-y $search-form-q-padding-x;
+
+  border-radius: $border-radius-xs !important;
+  color: $charcoal;
+
+  &.sort-select {
+    height: $search-form-height;
+    max-width: $search-form-select-width;
+    margin-right: $search-form-margin-x;
+    padding: 0 $search-form-select-padding-left 0 $search-form-select-padding-right;
+
+    background: url("https://libraries.emory.edu/assets/icons/php/icon.php?id=material-keyboard_arrow_down&color=5387F7&size[width]=20&size[height]=20") no-repeat right 0.5rem center;
+    border-radius:      $border-radius !important;
+  }
+}

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -158,7 +158,7 @@ $input-border-color:                $base-slate;
 $link-hover-transition:     all 0.25s ease;
 
 // Button
-$show-button-line-height:            1.325rem;
+$show-button-line-height:            1.25 rem;
 
 // Breadcrumb
 $bread-font-size-after:              $nav-divider-height;
@@ -174,3 +174,8 @@ $results-document-head-margin:       2.2rem;
 $results-pagination-margin:          0.563rem;
 $results-sort-padding:               3.25rem;
 
+// Advanced Search
+
+$advanced-search-subtitle-font-size:  $font-size-base * 1.5;
+$advanced-search-button-height:       3.125rem;
+$advanced-search-button-padding:      0.875rem 1.5625rem;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -496,7 +496,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, year_for_lux_ssi desc, title_ssort asc', label: 'relevance'
+    config.add_sort_field 'score desc, year_for_lux_ssi desc, title_ssort asc', label: 'Relevance'
     config.add_sort_field 'year_for_lux_ssi asc, title_ssort asc', label: 'Date (oldest)'
     config.add_sort_field 'year_for_lux_ssi desc, title_ssort asc', label: 'Date (newest)'
     config.add_sort_field 'creator_ssort asc', label: 'Creator (A-Z)'

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,0 +1,8 @@
+<%- search_fields_for_advanced_search.each do |key, field_def| -%>
+  <div class="form-group advanced-search-field">
+      <%= label_tag key, "#{field_def.label }", :class => "col-12 control-label" %>
+      <div class="col-sm-9">
+        <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+      </div>
+  </div>
+<%- end -%>

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,11 +1,11 @@
 <div class="sort-buttons pull-left">
-  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
+  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label mr-2") %>
   <%- sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
-  <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
+  <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select custom-select mb-3") %>
   <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
 </div>
 
-<div class="submit-buttons pull-right">
-  <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary advanced-search-start-over" %>
-  <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
+<div class="row submit-buttons">
+  <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"advanced-search-start-over rounded-0 ml-3" %>
+  <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'button link advanced-search-submit ml-2', :id => "advanced-search-submit" %>
 </div>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,0 +1,19 @@
+<% @page_title = "More Search Options - #{application_name}" %>
+
+<div class="advanced-search-form col-sm-12">
+  <div class="row align-items-center">
+    <h1 class="advanced page-header show-header mr-3">
+      <%= t('blacklight_advanced_search.form.title') %>
+    </h1>
+    <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"advanced-search-start-over rounded-0 mb-2 mb-0-md" %>
+  </div>
+
+  <div class="row">
+    <div class="col-md-8">
+      <%= render 'advanced_search_form' %>
+    </div>
+    <div class="col-md-4">
+      <%= render "advanced_search_help" %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -2,7 +2,7 @@
 <% if has_facet_values? facet_field_names(groupname), @response %>
 <div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md">
   <div class="navbar navbar-light navbar-expand-lg">
-    <h2 class="facets-heading">
+    <h2 class="homepage-content-heading">
       <% h2_title = request.fullpath != '/' ? "Limit Your Search" : t('blacklight.search.facets.title') %>
       <%= groupname.blank? ? h2_title : t("blacklight.search.facets-#{groupname}.title") %>
     </h2>


### PR DESCRIPTION
- Brings in Emory pattern library styles to advanced search page
- Adds Bootstrap utility classes to default views in advanced search gem
- Unifies capitalization of sort fields
- Fixes bug where facets heading had incorrect font size