### PR TITLE
Inserts and styles disclaimer in copyright card.

### DIFF
--- a/app/assets/stylesheets/lux.scss
+++ b/app/assets/stylesheets/lux.scss
@@ -6,6 +6,7 @@
 @import 'lux/colors';
 @import 'lux/constraint_button';
 @import 'lux/constraints';
+@import 'lux/copyright_card';
 @import 'lux/error_body';
 @import 'lux/explore_collections';
 @import 'lux/facets';

--- a/app/assets/stylesheets/lux/_copyright_card.scss
+++ b/app/assets/stylesheets/lux/_copyright_card.scss
@@ -1,0 +1,5 @@
+@import 'variables';
+
+p.copyright-dislaimer {
+  font-style: italic;
+}

--- a/app/views/catalog/_access_and_copyright_block.html.erb
+++ b/app/views/catalog/_access_and_copyright_block.html.erb
@@ -13,6 +13,7 @@
           <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
           <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
         <% end %>
+          <p class="copyright-dislaimer">Emory Libraries provides copyright information as a courtesy and makes no representation about copyright or other legal status of materials in its digital collections.</p>
       </dl>
     </div>
   </div>

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe "View a Work", type: :system, js: false do
     expect(page).to have_content('Copyright Date:')
     expect(page).to have_content('Re-Use License:')
     expect(page).to have_content('Access Restrictions:')
+    expect(page).to have_content('Emory Libraries provides copyright information as a courtesy and makes no representation about copyright or other legal status of materials in its digital collections.')
   end
 
   it 'has all correct metadata values' do


### PR DESCRIPTION
1. app/assets/stylesheets/*: creates styling for the text.
2. _access_and_copyright_block.html.erb: injects text into card structure.
3. view_work_spec.rb: uses test to check for text.