### PR TITLE
Cookie reboot

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -12,7 +12,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def cookie_pot
-    encryption_string = SecureRandom.hex
+    encryption_string = 1.day.from_now.to_s
     cookies["bearer_token"] = {
       value: encrypt_string(encryption_string),
       expires: 1.day.from_now,

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'openssl'
+require 'securerandom'
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def shibboleth
     Rails.logger.debug "OmniauthCallbacksController#shibboleth: request.env['omniauth.auth']: #{request.env['omniauth.auth']}"
@@ -11,8 +12,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def cookie_pot
+    encryption_string = SecureRandom.hex
     cookies["bearer_token"] = {
-      value: encrypt_string("This is a token value"),
+      value: encrypt_string(encryption_string),
       expires: 1.day.from_now,
       httponly: true,
       secure: request.ssl?,

--- a/spec/requests/omniauth_callbacks_requests_spec.rb
+++ b/spec/requests/omniauth_callbacks_requests_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OmniauthCallbacksController, :clean, type: :request do
   it "sets a cookie" do
     get '/users/auth/shibboleth/callback'
     expect(response.cookies).to include "bearer_token"
-    expect(decrypt_string(response.cookies["bearer_token"])).to eq "This is a token value"
+    expect(decrypt_string(response.cookies["bearer_token"])).not_to be false
   end
 
   def decrypt_string(encrypted_str)

--- a/spec/requests/omniauth_callbacks_requests_spec.rb
+++ b/spec/requests/omniauth_callbacks_requests_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OmniauthCallbacksController, :clean, type: :request do
   it "sets a cookie" do
     get '/users/auth/shibboleth/callback'
     expect(response.cookies).to include "bearer_token"
-    expect(decrypt_string(response.cookies["bearer_token"])).not_to be false
+    expect(decrypt_string(response.cookies["bearer_token"])).to eq 1.day.from_now.to_s
   end
 
   def decrypt_string(encrypted_str)


### PR DESCRIPTION
Use expiration date as cookie value, to make sure cookie values change and are even harder to spoof.