### PR TITLE
Integrates blacklight-citeproc gem into application.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'bcrypt_pbkdf'
 # Blacklight 7, because Blacklight 6 did not successfully deploy to production
 gem 'blacklight', ">= 7"
 gem 'blacklight-access_controls', git: 'https://github.com/projectblacklight/blacklight-access_controls', ref: '21e04f5'
+gem 'blacklight-citeproc'
 gem 'blacklight-marc', '>= 7.0.0.rc1'
 gem 'blacklight_advanced_search', '~>7.0'
 gem 'blacklight_range_limit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -886,6 +886,8 @@ GEM
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
     bcrypt_pbkdf (1.0.1)
+    bibtex-ruby (5.1.4)
+      latex-decode (~> 0.0)
     bindex (0.8.1)
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
@@ -896,6 +898,10 @@ GEM
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
+    blacklight-citeproc (0.0.4)
+      bibtex-ruby (>= 4.4.6)
+      citeproc-ruby (~> 1.1)
+      csl-styles (~> 1.0.1.9)
     blacklight-marc (7.0.0.rc1)
       blacklight (> 7.0.0.a, < 8.a)
       library_stdnums
@@ -943,6 +949,11 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    citeproc (1.0.10)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.12)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -961,6 +972,10 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.5)
+    csl (1.5.1)
+      namae (~> 1.0)
+    csl-styles (1.0.1.10)
+      csl (~> 1.0)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)
@@ -1026,6 +1041,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    latex-decode (0.3.1)
     library_stdnums (1.6.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -1047,6 +1063,7 @@ GEM
     minitest (5.13.0)
     multipart-post (2.1.1)
     mysql2 (0.5.2)
+    namae (1.0.1)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -1272,6 +1289,7 @@ DEPENDENCIES
   bixby
   blacklight (>= 7)
   blacklight-access_controls!
+  blacklight-citeproc
   blacklight-marc (>= 7.0.0.rc1)
   blacklight_advanced_search (~> 7.0)
   blacklight_range_limit

--- a/app/controllers/blacklight/citeproc/citation_controller.rb
+++ b/app/controllers/blacklight/citeproc/citation_controller.rb
@@ -35,7 +35,8 @@ module Blacklight::Citeproc
       render layout: false
     end
 
-    def print_multiple(ids)
+    def print_bookmarks
+      ids = bookmark_ids
       _, documents = get_docs(ids)
       bibtex = ::BibTeX::Bibliography.new
       documents.each { |d| fill_bibtex(bibtex, d) }
@@ -49,10 +50,6 @@ module Blacklight::Citeproc
       @citations.sort_by! { |c| c[:citation] }
       urlize_id
       render :print_multiple, layout: false
-    end
-
-    def print_bookmarks
-      print_multiple bookmark_ids
     end
 
     private

--- a/app/controllers/blacklight/citeproc/citation_controller.rb
+++ b/app/controllers/blacklight/citeproc/citation_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require 'bibtex'
+require 'citeproc'
+require 'csl/styles'
+
+module Blacklight::Citeproc
+  class BadConfigError < StandardError
+  end
+
+  class CitationController < ApplicationController
+    include Blacklight::Searchable
+
+    def initialize
+      @processors = []
+      @citations = []
+
+      throw BadConfigError, 'Catalog controller needs a config.citeproc section' unless blacklight_config.citeproc
+      @config = blacklight_config.citeproc
+      @config[:styles].each do |style|
+        @processors << ::CiteProc::Processor.new(format: 'html', style: style)
+      end
+    end
+
+    def print_single
+      _, document = get_docs
+      bibtex = ::BibTeX::Bibliography.new
+      fill_bibtex(bibtex, document)
+
+      @processors.each do |processor|
+        processor.import bibtex.to_citeproc
+        citation = processor.render(:bibliography, id: params[:id]).first.tr('{}', '')
+        citation_arr(citation, processor, params[:id])
+      end
+      urlize_id
+      render layout: false
+    end
+
+    def print_multiple(ids)
+      _, documents = get_docs(ids)
+      bibtex = ::BibTeX::Bibliography.new
+      documents.each { |d| fill_bibtex(bibtex, d) }
+      @citations = []
+
+      @processors.each do |processor|
+        processor.import bibtex.to_citeproc
+        bibliographies = ids.map { |id| [processor.render(:bibliography, id: id), id].flatten }
+        bibliographies.each { |bib, id| citation_arr(bib, processor, id) }
+      end
+      @citations.sort_by! { |c| c[:citation] }
+      urlize_id
+      render :print_multiple, layout: false
+    end
+
+    def print_bookmarks
+      print_multiple bookmark_ids
+    end
+
+    private
+
+      def bookmark_ids
+        current_user.bookmarks&.map { |b| b.document_id.to_s }
+      end
+
+      def get_docs(ids = params[:id])
+        search_service.fetch(ids)
+      end
+
+      def fill_bibtex(bibtex, document)
+        bibtex << document.export_as(:bibtex)
+      end
+
+      def urlize_id
+        @citations.each do |c|
+          c[:citation].gsub!(/#{c[:id]}/, "https://digital.library.emory.edu/purl/#{c[:id]}")
+        end
+      end
+
+      def citation_arr(bib, processor, id)
+        @citations << { citation: bib, label: processor.options[:style], id: id }
+      end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,6 +15,30 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    config.citeproc = {
+      #bibtex_field: 'bibtex_s' # Optional. If you are already indexing BibTeX into solr, this will be the preferred way to get bibliographic data
+      fields: {
+        author: 'creator_tesim',
+        edition: 'edition_tesim',
+        institution: 'institution_tesim',
+        organization: 'holding_repository_tesim',
+        publisher: 'publisher_tesim',
+        series: ['member_of_collections_ssim', 'series_title_tesim'],
+        title: 'title_tesim',
+        type: 'content_genres_tesim',
+        url: 'id',
+        year: 'date_issued_tesim'
+      },
+      styles: %w[apa chicago-fullnote-bibliography modern-language-association],
+      format: {
+        field: 'format',
+        default_format: :book,
+        mappings: {
+          book: ['Book', 'Musical Score', 'Ebook'],
+          misc: ['Map/Globe', 'Non-musical Recording', 'Musical Recording', 'Image', 'Software/Data', 'Video/Film']
+        }
+      }
+    }
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     # config.advanced_search[:qt] ||= 'advanced'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SolrDocument
   include Blacklight::Solr::Document
+  use_extension(Blacklight::Document::Bibtex)
+
   # The following shows how to setup this blacklight document to display marc documents
   extension_parameters[:marc_source_field] = :marc_ss
   extension_parameters[:marc_format_type] = :marcxml

--- a/app/views/blacklight/citeproc/citation/print_multiple.html.erb
+++ b/app/views/blacklight/citeproc/citation/print_multiple.html.erb
@@ -1,0 +1,10 @@
+<div class="modal-body">
+  <% style_count = @citations.map{|c| c[:style]}.uniq.size %>
+  <% counter = 0 %>
+<% @citations.each do |citation| %>
+  <% counter += 1 %>
+  <h3><%= t("blacklight.citeproc.styles.#{citation[:label]}") %></h3>
+  <%= citation[:citation].html_safe %>
+  <%= "<p></p>".html_safe if counter % 3 == 0 %>
+<% end %>
+</div>

--- a/app/views/blacklight/citeproc/citation/print_multiple.html.erb
+++ b/app/views/blacklight/citeproc/citation/print_multiple.html.erb
@@ -1,4 +1,9 @@
 <div class="modal-body">
+  <p>
+    <i>
+      Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.
+    </i>
+  </p>
   <% style_count = @citations.map{|c| c[:style]}.uniq.size %>
   <% counter = 0 %>
 <% @citations.each do |citation| %>

--- a/app/views/blacklight/citeproc/citation/print_single.html.erb
+++ b/app/views/blacklight/citeproc/citation/print_single.html.erb
@@ -1,0 +1,6 @@
+<div class="modal-body">
+<% @citations.each do |citation| %>
+  <h3><%= t("blacklight.citeproc.styles.#{citation[:label]}") %></h3>
+  <%= citation[:citation].html_safe %>
+<% end %>
+</div>

--- a/app/views/blacklight/citeproc/citation/print_single.html.erb
+++ b/app/views/blacklight/citeproc/citation/print_single.html.erb
@@ -1,4 +1,9 @@
 <div class="modal-body">
+  <p>
+    <i>
+      Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.
+    </i>
+  </p>
 <% @citations.each do |citation| %>
   <h3><%= t("blacklight.citeproc.styles.#{citation[:label]}") %></h3>
   <%= citation[:citation].html_safe %>

--- a/config/locales/blacklight-citeproc.en.yml
+++ b/config/locales/blacklight-citeproc.en.yml
@@ -1,0 +1,7 @@
+en:
+  blacklight:
+    citeproc:
+      styles:
+        apa: APA, 6th edition
+        chicago-fullnote-bibliography: Chicago
+        modern-language-association: MLA

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@
 Rails.application.routes.draw do
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   mount Blacklight::Engine => '/'
+
+  get '/catalog/:id/citation' => 'blacklight/citeproc/citation#print_single'
+  get '/bookmarks/citation' => 'blacklight/citeproc/citation#print_bookmarks'
+
   mount BlacklightAdvancedSearch::Engine => '/'
 
   concern :marc_viewable, Blacklight::Marc::Routes::MarcViewable.new

--- a/spec/controllers/citation_controller_spec.rb
+++ b/spec/controllers/citation_controller_spec.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 require 'rails_helper'
+include Warden::Test::Helpers
 
 RSpec.describe Blacklight::Citeproc::CitationController, type: :controller do
   before do
     config = CatalogController.blacklight_config.citeproc
     solr = Blacklight.default_index.connection
-    solr.add(work_attributes)
+    solr.add([work_attributes, work_attributes2])
     solr.commit
     controller.instance_variable_set(:@config, config)
+    sign_in user
   end
 
   let(:id) { '123' }
+  let(:id2) { '030prr4xkj-cor' }
   let(:work_attributes) { CURATE_GENERIC_WORK }
+  let(:work_attributes2) { PARENT_CURATE_GENERIC_WORK }
+  let(:user) { FactoryBot.create(:user) }
 
   describe '#print_single' do
     before { get :print_single, params: { id: id } }
@@ -40,6 +45,43 @@ RSpec.describe Blacklight::Citeproc::CitationController, type: :controller do
       values = assigns(:citations).map(&:values).flatten.compact
 
       expect(values.size).to eq(9)
+    end
+  end
+
+  describe '#print_bookmarks' do
+    before do
+      user.bookmarks.create(user_type: 'User', document_type: 'SolrDocument', document_id: id)
+      user.bookmarks.create(user_type: 'User', document_type: 'SolrDocument', document_id: id2)
+      get :print_bookmarks
+    end
+
+    it 'renders the print multiple template' do
+      expect(response.content_type).to eq "text/html"
+      expect(response).to render_template(:print_multiple)
+    end
+
+    it 'populates @citations instance variable' do
+      expect(assigns(:citations)).not_to be_empty
+      expect(assigns(:citations).size).to eq(6)
+    end
+
+    it 'populates @citations with the right keys' do
+      expect(assigns(:citations).first.keys).to eq([:citation, :label, :id])
+    end
+
+    it 'produces the expected citations' do
+      expect(assigns(:citations).first[:citation]).to eq(
+        "Creator, S. P. (1919/192X). <i>Emocad.</i> Emory University. https://digital.library.emory.edu/purl/030prr4xkj-cor"
+      )
+      expect(assigns(:citations)[3][:citation]).to eq(
+        "Smith, S. <i>The Title of my Work</i> (3rd ed.). New York Labor News Company. https://digital.library.emory.edu/purl/123"
+      )
+    end
+
+    it 'does not return an empty value' do
+      values = assigns(:citations).map(&:values).flatten.compact
+
+      expect(values.size).to eq(18)
     end
   end
 end

--- a/spec/controllers/citation_controller_spec.rb
+++ b/spec/controllers/citation_controller_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Blacklight::Citeproc::CitationController, type: :controller do
+  before do
+    config = CatalogController.blacklight_config.citeproc
+    solr = Blacklight.default_index.connection
+    solr.add(work_attributes)
+    solr.commit
+    controller.instance_variable_set(:@config, config)
+  end
+
+  let(:id) { '123' }
+  let(:work_attributes) { CURATE_GENERIC_WORK }
+
+  describe '#print_single' do
+    before { get :print_single, params: {id: id} }
+
+    it 'renders the print single template' do
+      expect(response.content_type).to eq "text/html"
+      expect(response).to render_template(:print_single)
+    end
+
+    it 'populates @citations instance variable' do
+      expect(assigns(:citations)).not_to be_empty
+      expect(assigns(:citations).size).to eq(3)
+    end
+
+    it 'populates @citations with the right keys' do
+      expect(assigns(:citations).first.keys).to eq([:citation, :label, :id])
+    end
+
+    it 'produces the expected citations' do
+      expect(assigns(:citations).first[:citation]).to eq(
+        "Smith, S. <i>The Title of my Work</i> (3rd ed.). New York Labor News Company. https://digital.library.emory.edu/purl/123"
+      )
+    end
+
+    it 'does not return an empty value' do
+      values = assigns(:citations).map(&:values).flatten.compact
+
+      expect(values.size).to eq(9)
+    end
+  end
+end

--- a/spec/controllers/citation_controller_spec.rb
+++ b/spec/controllers/citation_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Blacklight::Citeproc::CitationController, type: :controller do
   let(:work_attributes) { CURATE_GENERIC_WORK }
 
   describe '#print_single' do
-    before { get :print_single, params: {id: id} }
+    before { get :print_single, params: { id: id } }
 
     it 'renders the print single template' do
       expect(response.content_type).to eq "text/html"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/system/work_citation_spec.rb
+++ b/spec/system/work_citation_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe "View a Work Citation", type: :system, js: false do
   end
 
   it 'has the right headers' do
-    expect(page).to have_content('APA 6th edition')
-    expect(page).to have_content('Chicago Fullnote Bibliography')
-    expect(page).to have_content('Modern Language Association')
+    expect(page).to have_content('APA, 6th edition')
+    expect(page).to have_content('Chicago')
+    expect(page).to have_content('MLA')
   end
 
   it 'provides the right link 3 times' do

--- a/spec/system/work_citation_spec.rb
+++ b/spec/system/work_citation_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "View a Work Citation", type: :system, js: false do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(work_attributes)
+    solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
+    visit solr_document_path(id)
+    click_link('citationLink')
+  end
+
+  let(:id) { '123' }
+
+  let(:work_attributes) do
+    CURATE_GENERIC_WORK
+  end
+
+  it 'has a disclaimer' do
+    expect(page).to have_content('Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.')
+  end
+
+  it 'has the right headers' do
+    expect(page).to have_content('APA 6th edition')
+    expect(page).to have_content('Chicago Fullnote Bibliography')
+    expect(page).to have_content('Modern Language Association')
+  end
+
+  it 'provides the right link 3 times' do
+    expect(page).to have_content('https://digital.library.emory.edu/purl/123', count: 3)
+  end
+
+  it 'shows the APA correctly' do
+    expect(page).to have_content('Smith, S. The Title of my Work (3rd ed.). New York Labor News Company. https://digital.library.emory.edu/purl/123')
+  end
+
+  it 'shows the Chicago Fullnote correctly' do
+    expect(page).to have_content('Smith, Somebody. The Title of My Work. 3Rd ed. New York Labor News Company, n.d. https://digital.library.emory.edu/purl/123.')
+  end
+
+  it 'shows the MLA correctly' do
+    expect(page).to have_content('Smith, Somebody. The Title of My Work. 3Rd ed., New York Labor News Company, https://digital.library.emory.edu/purl/123.')
+  end
+end


### PR DESCRIPTION
1. Gemfile*: adds and incorporates needed gem and it's dependencies.
2. citation_controller.rb: overrides and refactors gem's original controller because
   error was occuring when attempting to print multiple bookmarks' citations.
3. catalog_controller.rb: institutes the configuration for the citation gem into the catalog controller.
4. solr_document.rb: allows the extension of Bibtex into a solr_document.
5. print_multiple.html.erb: creates a unique view for printing multiple citations, so that
   space may be incorporated in between each document's citation.
6. print_single.html.erb: overrides the gem's default in order to display the citations with appropriate styling.
7. routes.rb: removes the gem's routes and, instead, points to the refactored/retooled controller listed above.