### PR TITLE
Redirect PURLs to the catalog

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,10 @@ Rails.application.routes.draw do
   get "/about", to: "static#about"
   get "/copyright-reuse", to: "static#copyright_reuse"
 
+  # Redirect requests for PURLs to the same object in the catalog controller
+  # Status 303 is 'Found'. We don't want to suggest the object has moved.
+  get '/purl/:obj_id', to: redirect('/catalog/%{obj_id}', status: 303)
+
   match '/404', to: 'static#not_found', via: :all
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/requests/purl_redirection_spec.rb
+++ b/spec/requests/purl_redirection_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "PURL Redirection", :clean, type: :request do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([work_with_public_visibility])
+    solr.commit
+  end
+
+  let(:public_work_id) { '111-111-cor' }
+
+  let(:work_with_public_visibility) do
+    WORK_WITH_PUBLIC_VISIBILITY
+  end
+
+  it "redirects requests from /purl/:id to the catalog" do
+    get("/purl/#{public_work_id}")
+    expect(response).to have_http_status(303)
+    expect(response).to redirect_to("/catalog/#{public_work_id}")
+  end
+end


### PR DESCRIPTION
The redirect uses status 303: 'Found', because we don't want to suggest the object has moved.