### PR TITLE
Remove unneeded links on Bookmarks page

### DIFF
--- a/app/assets/stylesheets/lux/_bookmarks_nav.scss
+++ b/app/assets/stylesheets/lux/_bookmarks_nav.scss
@@ -1,5 +1,5 @@
 @import 'variables';
 
-a#citationLink.nav-link::after, a#emailLink.nav-link::after {
+a#citationLink.nav-link::after, a.help-show-link.nav-link::after, a.feedback-show-link.nav-link::after {
   position: relative;
 }

--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -1,0 +1,11 @@
+<% # [Blacklight overwrite] Do not display Help or Feedback links on Bookmarks page #L5 %>
+
+<ul class="<%= controller_name %>Tools nav nav-pills">
+  <%= render_show_doc_actions document_list, document: nil, document_list: @response.documents, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h) do |config, inner| %>
+    <% if inner.include?("Cite") %>
+      <li class="nav-item">
+        <%= inner %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>


### PR DESCRIPTION
- Removes Help and Feedback links from Bookmarks page
- Removes errant gray pipe on top right of Bookmarks page