### PR TITLE
Reduce image carousel rotation interval

### DIFF
--- a/app/views/catalog/_hero_image.html.erb
+++ b/app/views/catalog/_hero_image.html.erb
@@ -1,6 +1,6 @@
 <% presenter = HeroImagePresenter.new %>
 <% images = presenter.images %>
-<div class="carousel slide mt-3 mb-3" data-ride="carousel" data-interval="10000">
+<div class="carousel slide mt-3 mb-3" data-ride="carousel" data-interval="6000">
   <div class="carousel-caption">
     <h1 class="intro-hero-title">Emory Digital Collections</h1>
   </div>


### PR DESCRIPTION
- Hero image rotation interval should now be 6 seconds, per product owner