### PR TITLE
Creates the appropriately styled and formatted citation modal. #490

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,10 @@ gem 'blacklight-marc', '>= 7.0.0.rc1'
 gem 'blacklight_advanced_search', '~>7.0'
 gem 'blacklight_range_limit'
 gem 'bootstrap', '~> 4.0'
+gem 'citeproc-ruby'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
+gem 'csl-styles'
 gem 'devise'
 gem 'dotenv-rails'
 # Needed for support of OpenSSH keys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -943,6 +943,11 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    citeproc (1.0.10)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.12)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -961,6 +966,10 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.5)
+    csl (1.5.1)
+      namae (~> 1.0)
+    csl-styles (1.0.1.10)
+      csl (~> 1.0)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)
@@ -1047,6 +1056,7 @@ GEM
     minitest (5.13.0)
     multipart-post (2.1.1)
     mysql2 (0.5.2)
+    namae (1.0.1)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -1286,8 +1296,10 @@ DEPENDENCIES
   capistrano-rails-collection
   capistrano-sidekiq
   capybara
+  citeproc-ruby
   coffee-rails (~> 4.2)
   coveralls
+  csl-styles
   devise
   dotenv-rails
   ed25519

--- a/app/assets/stylesheets/lux.scss
+++ b/app/assets/stylesheets/lux.scss
@@ -5,6 +5,7 @@
 @import 'lux/bookmarks_nav';
 @import 'lux/breadcrumbs';
 @import 'lux/cards';
+@import 'lux/citations';
 @import 'lux/collection_image';
 @import 'lux/colors';
 @import 'lux/constraint_button';

--- a/app/assets/stylesheets/lux/_citations.scss
+++ b/app/assets/stylesheets/lux/_citations.scss
@@ -1,0 +1,10 @@
+@import 'variables';
+
+h1.citation-title.show-header {
+  text-align: left;
+}
+
+div.modal-header.citations {
+  border-bottom: 0;
+  padding-bottom: 0;
+}

--- a/app/helpers/citation_helper.rb
+++ b/app/helpers/citation_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require './lib/emory/citation_formatter'
+
+module CitationHelper
+  def mla_citation_txt(document)
+    generator = Emory::CitationFormatter.new(document)
+    generator.citation_for('modern-language-association')
+  end
+
+  def apa_citation_txt(document)
+    generator = Emory::CitationFormatter.new(document)
+    generator.citation_for('apa')
+  end
+
+  def chicago_citation_txt(document)
+    generator = Emory::CitationFormatter.new(document)
+    generator.citation_for('chicago-fullnote-bibliography')
+  end
+end

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,17 +1,18 @@
-<div class="modal-header">
-  <h1><%= t('blacklight.citation.header') %></h1>
+<div class="modal-header citations">
+  <p><i><small>Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.</small></i></p>
   <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
 <div class="modal-body">
+  
   <% @documents.each do |document| %>
-    <h1 class="modal-title"><%= document_heading(document) %></h1>
-      <h2><%= t('blacklight.citation.mla') %></h2>
+    <h1 class="modal-title show-header citation-title"><%= document_heading(document) %></h1>
+      <h3 class="heading -h3"><%= t('blacklight.citation.mla') %></h3>
       <%= mla_citation_txt(document).html_safe %><br/><br/>
-      <h2><%= t('blacklight.citation.apa') %></h2>
+      <h3 class="heading -h3"><%= t('blacklight.citation.apa') %></h3>
       <%= apa_citation_txt(document).html_safe %><br/><br/>
-      <h2><%= t('blacklight.citation.chicago') %></h2>
-      <%= chicago_citation_txt(document).html_safe %>
+      <h3 class="heading -h3"><%= t('blacklight.citation.chicago') %></h3>
+      <%= chicago_citation_txt(document).html_safe %><br><br>
   <% end %>
 </div>

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <h1><%= t('blacklight.citation.header') %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <% @documents.each do |document| %>
+    <h1 class="modal-title"><%= document_heading(document) %></h1>
+      <h2><%= t('blacklight.citation.mla') %></h2>
+      <%= mla_citation_txt(document).html_safe %><br/><br/>
+      <h2><%= t('blacklight.citation.apa') %></h2>
+      <%= apa_citation_txt(document).html_safe %><br/><br/>
+      <h2><%= t('blacklight.citation.chicago') %></h2>
+      <%= chicago_citation_txt(document).html_safe %>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,5 @@ module LuxBl7
     # -- all .rb files in that directory are automatically loaded.
 
     config.exceptions_app = routes
-    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module LuxBl7
     # -- all .rb files in that directory are automatically loaded.
 
     config.exceptions_app = routes
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -14,7 +14,6 @@ en:
         search:
           placeholder: 'Search Digital Collections'
     citation:
-      header: 'Document(s) Citations'
       apa: 'APA, 6th edition'
       chicago-fullnote-bibliography: 'Chicago'
       modern-language-association: 'MLA'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -13,3 +13,8 @@ en:
       form:
         search:
           placeholder: 'Search Digital Collections'
+    citation:
+      header: 'Document(s) Citations'
+      apa: 'APA, 6th edition'
+      chicago-fullnote-bibliography: 'Chicago'
+      modern-language-association: 'MLA'

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require 'citeproc'
+require './lib/emory/citation_string_processor'
 
 module Emory
   class CitationFormatter
+    include CitationStringProcessor
     attr_accessor :obj, :default_citations
 
     def initialize(obj)
@@ -22,89 +24,12 @@ module Emory
         CiteProc::Item.new(key_val_chunk_1.merge(key_val_chunk_2).merge(key_val_chunk_3))
       end
 
-      def url
-        return unless obj[:id]
-        "https://digital.library.emory.edu/purl/#{obj[:id]}"
-      end
-
-      def proc_mid_com(field)
-        "#{field&.first}, " if field.present?
-      end
-
-      def proc_mid_per(field)
-        "#{field&.first}. " if field.present?
-      end
-
       def mla_url_test
         [obj[:holding_repository_tesim], obj[:edition_tesim], obj[:publisher_tesim], obj[:date_issued_tesim]].any?(&:present?)
       end
 
-      def  apa_edition
-        ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
-      end
-
-      def sanitized_citation(citation)
-        if !citation.include?(url) && citation.last != "."
-          citation << ". #{url}."
-        elsif !citation.include?(url) && citation.last == "."
-          citation << " #{url}."
-        else
-          citation
-        end
-      end
-
-      def auth_no_per
-        return obj[:creator_tesim].map { |a| a.first(a.size - 1) } if obj[:creator_tesim]&.any? { |a| a&.split('')&.last == '.' }
-        obj[:creator_tesim]
-      end
-
-      def sanitized_apa_auth
-        return apa_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
-        "#{auth_no_per&.join(', & ')}. " unless obj[:creator_tesim].blank?
-      end
-
-      def sanitized_mla_auth
-        return mla_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
-        "#{auth_no_per&.join(', ')}. " unless obj[:creator_tesim].blank?
-      end
-
-      def sanitized_chic_auth
-        "#{auth_no_per&.join(', ')}, " unless auth_no_per.nil?
-      end
-
-      def apa_default
-        [
-          sanitized_apa_auth, ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
-          ("[#{obj[:title_tesim]&.first}#{apa_edition}]. " unless obj[:title_tesim].nil?),
-          proc_mid_com(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
-        ].join('')
-      end
-
-      def chicago_default
-        [
-          sanitized_chic_auth, proc_mid_com(obj[:title_tesim]),
-          proc_mid_com(obj[:date_issued_tesim]), proc_mid_com(obj[:member_of_collections_ssim]),
-          proc_mid_per(obj[:holding_repository_tesim]), url, "."
-        ].join('')
-      end
-
-      def mla_default
-        [
-          sanitized_mla_auth, proc_mid_per(obj[:title_tesim]), proc_mid_per(obj[:date_issued_tesim]),
-          proc_mid_per(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
-        ].join('')
-      end
-
       def abnormal_chars?
         obj[:creator_tesim]&.any? { |a| a.match(/[^A-Za-z\s]+/) }
-      end
-
-      def apa_creator_name
-        "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1)&.map(&:first)&.join('. ') }&.join(', & ')}. "
-      end
-
-      def mla_creator_name
-        "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')}. "
       end
 
       def key_val_chunk_1

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'citeproc'
+require 'csl/styles'
 require './lib/emory/citation_string_processor'
 
 module Emory
@@ -9,7 +10,11 @@ module Emory
 
     def initialize(obj)
       @obj = obj
-      @default_citations = { "apa": apa_default, "chicago-fullnote-bibliography": chicago_default, "modern-language-association": mla_default }
+      @default_citations = {
+        "apa": apa_default_citation,
+        "chicago-fullnote-bibliography": chicago_default_citation,
+        "modern-language-association": mla_default_citation
+      }
     end
 
     def citation_for(style)
@@ -21,32 +26,56 @@ module Emory
     private
 
       def item
-        CiteProc::Item.new(key_val_chunk_1.merge(key_val_chunk_2).merge(key_val_chunk_3))
+        CiteProc::Item.new(key_value_chunk_1.merge(key_value_chunk_2).merge(key_value_chunk_3))
       end
 
       def mla_url_test
-        [obj[:holding_repository_tesim], obj[:edition_tesim], obj[:publisher_tesim], obj[:date_issued_tesim]].any?(&:present?)
+        [
+          obj[:holding_repository_tesim],
+          obj[:edition_tesim],
+          obj[:publisher_tesim],
+          obj[:date_issued_tesim]
+        ].any?(&:present?)
       end
 
       def abnormal_chars?
-        obj[:creator_tesim]&.any? { |a| a.match(/[^A-Za-z\s]+/) }
+        obj[:creator_tesim]&.any? { |a| a.match(/[^\p{L}\s]+/) }
       end
 
-      def key_val_chunk_1
-        { id: :item, abstract: obj[:abstract_tesim]&.join(', '), archive_location: obj[:sublocation_tesim]&.join(', '), author: obj[:creator_tesim]&.join(', '),
-          "call-number": obj[:local_call_number_tesim]&.join(', '), edition: obj[:edition_tesim]&.join(', '), institution: obj[:institution_tesim]&.join(', ') }
+      def key_value_chunk_1
+        {
+          id: :item,
+          abstract: obj[:abstract_tesim]&.join(', '),
+          archive_location: obj[:sublocation_tesim]&.join(', '),
+          author: obj[:creator_tesim]&.join(', '),
+          "call-number": obj[:local_call_number_tesim]&.join(', '),
+          edition: obj[:edition_tesim]&.join(', '),
+          institution: obj[:institution_tesim]&.join(', ')
+        }
       end
 
-      def key_val_chunk_2
-        { archive: obj[:holding_repository_tesim]&.join(', '), publisher: obj[:publisher_tesim]&.join(', '), title: obj[:title_tesim]&.join(', '),
-          "collection-title": obj[:member_of_collections_ssim]&.join(', '), type: [obj[:human_readable_content_type_ssim]&.first&.downcase]&.join(', '),
-          url: url, issued: (obj[:date_issued_tesim] || obj[:year_issued_isim] || obj[:year_created_isim] || [0])&.first&.to_i }
+      def key_value_chunk_2
+        {
+          archive: obj[:holding_repository_tesim]&.join(', '),
+          publisher: obj[:publisher_tesim]&.join(', '),
+          title: obj[:title_tesim]&.join(', '),
+          "collection-title": obj[:member_of_collections_ssim]&.join(', '),
+          type: [obj[:human_readable_content_type_ssim]&.first&.downcase]&.join(', '),
+          url: url,
+          issued: (obj[:date_issued_tesim] || obj[:year_issued_isim] || obj[:year_created_isim] || [0])&.first&.to_i
+        }
       end
 
-      def key_val_chunk_3
-        { dimensions: obj[:extent_tesim]&.join(', '), event: obj[:conference_name_tesim]&.join(', '), genre: obj[:content_genres_tesim]&.join(', '),
-          ISBN: obj[:isbn_tesim]&.join(', '), ISSN: obj[:issn_tesim]&.join(', '), keyword: obj[:keywords_tesim]&.join(', '),
-          "publisher-place": obj[:place_of_production_tesim]&.join(', ') }
+      def key_value_chunk_3
+        {
+          dimensions: obj[:extent_tesim]&.join(', '),
+          event: obj[:conference_name_tesim]&.join(', '),
+          genre: obj[:content_genres_tesim]&.join(', '),
+          ISBN: obj[:isbn_tesim]&.join(', '),
+          ISSN: obj[:issn_tesim]&.join(', '),
+          keyword: obj[:keywords_tesim]&.join(', '),
+          "publisher-place": obj[:place_of_production_tesim]&.join(', ')
+        }
       end
   end
 end

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -1,44 +1,123 @@
+# frozen_string_literal: true
 module Emory
   class CitationFormatter
-    attr_accessor :object
+    attr_accessor :obj, :default_citations
 
-    def initialize(object, style)
-      @object = object
-      @style = style
+    def initialize(obj)
+      @obj = obj
+      @default_citations = { "apa": apa_default, "chicago-fullnote-bibliography": chicago_default, "modern-language-association": mla_default }
     end
 
-    def citation
-      CiteProc::Processor
-        .new(style: @style, format: 'html')
-        .import(item)
-        .render(:bibliography, id: :item)
-        .first
+    def citation_for(style)
+      sanitized_citation(CiteProc::Processor.new(style: style, format: 'html').import(item).render(:bibliography, id: :item).first)
     rescue CiteProc::Error, TypeError, ArgumentError
-      "#{@object['creator_tesim']&.join(', ')}. (#{@object['date_issued_tesim']&.first}). <i>#{@object['title_tesim']&.first}</i>. #{@object['publisher_tesim']&.first}."
+      @default_citations[style.to_sym]
     end
 
-    def item
-      CiteProc::Item.new(
-        author: object['creator_tesim'],
-        edition: object['edition_tesim'],
-        institution: object['institution_tesim'],
-        organization: object['holding_repository_tesim'],
-        publisher: object['publisher_tesim'],
-        series: [object['member_of_collections_ssim'], object['series_title_tesim']],
-        title: object['title_tesim'],
-        type: object['content_genres_tesim'],
-        url: object['id'],
-        year: object['date_issued_tesim']
-      )
-    end
+    private
 
-    def doi
-      object.identifier.first
-    end
+      def item
+        CiteProc::Item.new(key_val_chunk_1.merge(key_val_chunk_2).merge(key_val_chunk_3))
+      end
 
-    def url
-      return unless object['id']
-      "https://digital.library.emory.edu/purl/#{object.id}"
-    end
+      def url
+        return unless obj[:id]
+        "https://digital.library.emory.edu/purl/#{obj[:id]}"
+      end
+
+      def proc_mid_com(field)
+        "#{field&.first}, " if field.present?
+      end
+
+      def proc_mid_per(field)
+        "#{field&.first}. " if field.present?
+      end
+
+      def mla_url_test
+        [obj[:holding_repository_tesim], obj[:edition_tesim], obj[:publisher_tesim], obj[:date_issued_tesim]].any?(&:present?)
+      end
+
+      def  apa_edition
+        ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
+      end
+
+      def sanitized_citation(citation)
+        if !citation.include?(url) && citation.last != "."
+          citation << ". #{url}."
+        elsif !citation.include?(url) && citation.last == "."
+          citation << " #{url}."
+        else
+          citation
+        end
+      end
+
+      def auth_no_per
+        if obj[:creator_tesim]&.any? { |a| a&.split('')&.last == '.' }
+          return obj[:creator_tesim].map{ |a| a.first(a.size - 1) }
+        end
+        obj[:creator_tesim]
+      end
+
+      def sanitized_apa_auth
+        return apa_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
+        auth_no_per&.join(', & ') unless obj[:creator_tesim].blank?
+      end
+
+      def sanitized_mla_auth
+        return mla_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
+        auth_no_per&.join(', ') unless obj[:creator_tesim].blank?
+      end
+
+      def apa_default
+        [
+          (sanitized_apa_auth.nil? ? nil : "#{sanitized_apa_auth}. "), ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
+          ("[#{obj[:title_tesim]&.first}#{apa_edition}]. " unless obj[:title_tesim].nil?),
+          proc_mid_com(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+        ].join('')
+      end
+
+      def chicago_default
+        [
+          (auth_no_per.nil? ? nil : "#{auth_no_per&.join(', ')}, "), proc_mid_com(obj[:title_tesim]),
+          proc_mid_com(obj[:date_issued_tesim]), proc_mid_com(obj[:member_of_collections_ssim]),
+          proc_mid_per(obj[:holding_repository_tesim]), url, "."
+        ].join('')
+      end
+
+      def mla_default
+        [
+          (sanitized_mla_auth.nil? ? nil : "#{sanitized_mla_auth}. "), proc_mid_per(obj[:title_tesim]), proc_mid_per(obj[:date_issued_tesim]),
+          proc_mid_per(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+        ].join('')
+      end
+
+      def abnormal_chars?
+        obj[:creator_tesim]&.any? { |a| a.match(/[^A-Za-z\s]+/) }
+      end
+
+      def apa_creator_name
+        "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1)&.map(&:first)&.join('. ') }&.join(', & ')}."
+      end
+
+      def mla_creator_name
+        obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')
+      end
+
+      def key_val_chunk_1
+        { id: :item, abstract: obj[:abstract_tesim]&.join(', '), archive_location: obj[:sublocation_tesim]&.join(', '), author: obj[:creator_tesim]&.join(', '),
+          "call-number": obj[:local_call_number_tesim]&.join(', '), edition: obj[:edition_tesim]&.join(', '), institution: obj[:institution_tesim]&.join(', ') }
+      end
+
+      def key_val_chunk_2
+        { archive: obj[:holding_repository_tesim]&.join(', '), publisher: obj[:publisher_tesim]&.join(', '), title: obj[:title_tesim]&.join(', '),
+          "collection-title": obj[:member_of_collections_ssim]&.join(', '), type: [obj[:human_readable_content_type_ssim]&.first&.downcase]&.join(', '),
+          url: url, issued: obj[:date_issued_tesim] }
+      end
+
+      def key_val_chunk_3
+        { dimensions: obj[:extent_tesim]&.join(', '), event: obj[:conference_name_tesim]&.join(', '), genre: obj[:content_genres_tesim]&.join(', '),
+          ISBN: obj[:isbn_tesim]&.join(', '), ISSN: obj[:issn_tesim]&.join(', '), keyword: obj[:keywords_tesim]&.join(', '),
+          "publisher-place": obj[:place_of_production_tesim]&.join(', ') }
+      end
   end
 end

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -1,0 +1,44 @@
+module Emory
+  class CitationFormatter
+    attr_accessor :object
+
+    def initialize(object, style)
+      @object = object
+      @style = style
+    end
+
+    def citation
+      CiteProc::Processor
+        .new(style: @style, format: 'html')
+        .import(item)
+        .render(:bibliography, id: :item)
+        .first
+    rescue CiteProc::Error, TypeError, ArgumentError
+      "#{@object['creator_tesim']&.join(', ')}. (#{@object['date_issued_tesim']&.first}). <i>#{@object['title_tesim']&.first}</i>. #{@object['publisher_tesim']&.first}."
+    end
+
+    def item
+      CiteProc::Item.new(
+        author: object['creator_tesim'],
+        edition: object['edition_tesim'],
+        institution: object['institution_tesim'],
+        organization: object['holding_repository_tesim'],
+        publisher: object['publisher_tesim'],
+        series: [object['member_of_collections_ssim'], object['series_title_tesim']],
+        title: object['title_tesim'],
+        type: object['content_genres_tesim'],
+        url: object['id'],
+        year: object['date_issued_tesim']
+      )
+    end
+
+    def doi
+      object.identifier.first
+    end
+
+    def url
+      return unless object['id']
+      "https://digital.library.emory.edu/purl/#{object.id}"
+    end
+  end
+end

--- a/lib/emory/citation_string_processor.rb
+++ b/lib/emory/citation_string_processor.rb
@@ -2,19 +2,18 @@
 
 module CitationStringProcessor
   def url
-    return unless obj[:id]
-    "https://digital.library.emory.edu/purl/#{obj[:id]}"
+    "https://digital.library.emory.edu/purl/#{obj[:id]}" if obj[:id]
   end
 
-  def proc_mid_com(field)
+  def append_string_with_comma(field)
     "#{field&.first}, " if field.present?
   end
 
-  def proc_mid_per(field)
+  def append_string_with_period(field)
     "#{field&.first}. " if field.present?
   end
 
-  def  apa_edition
+  def apa_edition
     ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
   end
 
@@ -28,53 +27,66 @@ module CitationStringProcessor
     end
   end
 
-  def auth_no_per
+  def author_name_no_period
     return obj[:creator_tesim].map { |a| a.first(a.size - 1) } if obj[:creator_tesim]&.any? { |a| a&.split('')&.last == '.' }
     obj[:creator_tesim]
   end
 
-  def sanitized_apa_auth
-    return apa_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
-    "#{auth_no_per&.join(', & ')}. " unless obj[:creator_tesim].blank?
+  def formatted_apa_author
+    return joined_apa_author_names unless abnormal_chars? || obj[:creator_tesim].blank?
+    "#{author_name_no_period&.join(', & ')}. " unless obj[:creator_tesim].blank?
   end
 
-  def sanitized_mla_auth
-    return mla_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
-    "#{auth_no_per&.join(', ')}. " unless obj[:creator_tesim].blank?
+  def formatted_mla_author
+    return joined_mla_author_names unless abnormal_chars? || obj[:creator_tesim].blank?
+    "#{author_name_no_period&.join(', ')}. " unless obj[:creator_tesim].blank?
   end
 
-  def sanitized_chic_auth
-    "#{auth_no_per&.join(', ')}, " unless auth_no_per.nil?
+  def formatted_chicago_author
+    "#{author_name_no_period&.join(', ')}, " unless author_name_no_period.nil?
   end
 
-  def apa_default
+  def apa_default_citation
     [
-      sanitized_apa_auth, ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
+      formatted_apa_author,
+      ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
       ("[#{obj[:title_tesim]&.first}#{apa_edition}]. " unless obj[:title_tesim].nil?),
-      proc_mid_com(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+      append_string_with_comma(obj[:member_of_collections_ssim]),
+      append_string_with_period(obj[:holding_repository_tesim]),
+      url,
+      "."
     ].join('')
   end
 
-  def chicago_default
+  def chicago_default_citation
     [
-      sanitized_chic_auth, proc_mid_com(obj[:title_tesim]),
-      proc_mid_com(obj[:date_issued_tesim]), proc_mid_com(obj[:member_of_collections_ssim]),
-      proc_mid_per(obj[:holding_repository_tesim]), url, "."
+      formatted_chicago_author,
+      append_string_with_comma(obj[:title_tesim]),
+      append_string_with_comma(obj[:date_issued_tesim]),
+      append_string_with_comma(obj[:member_of_collections_ssim]),
+      append_string_with_period(obj[:holding_repository_tesim]),
+      url,
+      "."
     ].join('')
   end
 
-  def mla_default
+  def mla_default_citation
     [
-      sanitized_mla_auth, proc_mid_per(obj[:title_tesim]), proc_mid_per(obj[:date_issued_tesim]),
-      proc_mid_per(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+      formatted_mla_author,
+      append_string_with_period(obj[:title_tesim]),
+      append_string_with_period(obj[:date_issued_tesim]),
+      append_string_with_period(obj[:member_of_collections_ssim]),
+      append_string_with_period(obj[:holding_repository_tesim]),
+      url,
+      "."
     ].join('')
   end
 
-  def apa_creator_name
+  def joined_apa_author_names
     "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1)&.map(&:first)&.join('. ') }&.join(', & ')}. "
   end
 
-  def mla_creator_name
+  def joined_mla_author_names
     "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')}. "
   end
 end

--- a/lib/emory/citation_string_processor.rb
+++ b/lib/emory/citation_string_processor.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module CitationStringProcessor
+  def url
+    return unless obj[:id]
+    "https://digital.library.emory.edu/purl/#{obj[:id]}"
+  end
+
+  def proc_mid_com(field)
+    "#{field&.first}, " if field.present?
+  end
+
+  def proc_mid_per(field)
+    "#{field&.first}. " if field.present?
+  end
+
+  def  apa_edition
+    ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
+  end
+
+  def sanitized_citation(citation)
+    if !citation.include?(url) && citation.last != "."
+      citation << ". #{url}."
+    elsif !citation.include?(url) && citation.last == "."
+      citation << " #{url}."
+    else
+      citation
+    end
+  end
+
+  def auth_no_per
+    return obj[:creator_tesim].map { |a| a.first(a.size - 1) } if obj[:creator_tesim]&.any? { |a| a&.split('')&.last == '.' }
+    obj[:creator_tesim]
+  end
+
+  def sanitized_apa_auth
+    return apa_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
+    "#{auth_no_per&.join(', & ')}. " unless obj[:creator_tesim].blank?
+  end
+
+  def sanitized_mla_auth
+    return mla_creator_name unless abnormal_chars? || obj[:creator_tesim].blank?
+    "#{auth_no_per&.join(', ')}. " unless obj[:creator_tesim].blank?
+  end
+
+  def sanitized_chic_auth
+    "#{auth_no_per&.join(', ')}, " unless auth_no_per.nil?
+  end
+
+  def apa_default
+    [
+      sanitized_apa_auth, ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
+      ("[#{obj[:title_tesim]&.first}#{apa_edition}]. " unless obj[:title_tesim].nil?),
+      proc_mid_com(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+    ].join('')
+  end
+
+  def chicago_default
+    [
+      sanitized_chic_auth, proc_mid_com(obj[:title_tesim]),
+      proc_mid_com(obj[:date_issued_tesim]), proc_mid_com(obj[:member_of_collections_ssim]),
+      proc_mid_per(obj[:holding_repository_tesim]), url, "."
+    ].join('')
+  end
+
+  def mla_default
+    [
+      sanitized_mla_auth, proc_mid_per(obj[:title_tesim]), proc_mid_per(obj[:date_issued_tesim]),
+      proc_mid_per(obj[:member_of_collections_ssim]), proc_mid_per(obj[:holding_repository_tesim]), url, "."
+    ].join('')
+  end
+
+  def apa_creator_name
+    "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1)&.map(&:first)&.join('. ') }&.join(', & ')}. "
+  end
+
+  def mla_creator_name
+    "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')}. "
+  end
+end

--- a/spec/lib/citation_formatter_spec.rb
+++ b/spec/lib/citation_formatter_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Emory::CitationFormatter do
     expect(cit_gen.default_citations.values.uniq.size).to eq(3)
   end
 
+  it 'formats each default_citation correctly' do
+    expect(cit_gen.default_citations[:"chicago-fullnote-bibliography"]).to(
+      eq("Sample Parent Creator, Emocad., 1919/192X, Emory University Yearbooks, Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.")
+    )
+    expect(cit_gen.default_citations[:apa]).to(
+      eq("Creator, S. P. (1919/192X)[Emocad.]. Emory University Yearbooks, Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.")
+    )
+    expect(cit_gen.default_citations[:'modern-language-association']).to(
+      eq("Creator, Sample Parent. Emocad.. 1919/192X. Emory University Yearbooks. Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.")
+    )
+  end
+
   it 'always includes the url' do
     url = cit_gen.send(:url)
 

--- a/spec/lib/citation_formatter_spec.rb
+++ b/spec/lib/citation_formatter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require './lib/emory/citation_formatter'
+
+RSpec.describe Emory::CitationFormatter do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add(document)
+    solr.commit
+  end
+
+  let(:document) { PARENT_CURATE_GENERIC_WORK }
+  let(:cit_gen) { described_class.new(document) }
+  let(:chicago) { 'chicago-fullnote-bibliography' }
+  let(:apa) { 'apa' }
+  let(:mla) { 'modern-language-association' }
+
+  it 'creates a citation' do
+    expect(cit_gen.citation_for(apa)).not_to be_empty
+    expect(cit_gen.citation_for(chicago)).not_to be_empty
+    expect(cit_gen.citation_for(mla)).not_to be_empty
+  end
+
+  it 'creates three unique default citations' do
+    expect(cit_gen.default_citations.values.uniq.size).to eq(3)
+  end
+
+  it 'always includes the url' do
+    url = cit_gen.send(:url)
+
+    expect(cit_gen.citation_for(apa)).to include(url)
+    expect(cit_gen.citation_for(chicago)).to include(url)
+    expect(cit_gen.citation_for(mla)).to include(url)
+  end
+
+  it "sanitizes the APA author name correctly in default citation if it's properly formatted" do
+    expect(cit_gen.default_citations[:apa]).to include('Creator, S. P.')
+  end
+
+  it "sanitizes the MLA author name correctly in default citation if it's properly formatted" do
+    expect(cit_gen.default_citations[mla.to_sym]).to include('Creator, Sample Parent')
+  end
+end

--- a/spec/system/work_citation_spec.rb
+++ b/spec/system/work_citation_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "View a Work Citation", type: :system, js: false do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(work_attributes)
+    solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
+    visit solr_document_path(id)
+    click_link('citationLink')
+  end
+
+  let(:id) { "030prr4xkj-cor" }
+  let(:work_attributes) { PARENT_CURATE_GENERIC_WORK }
+
+  it 'has a disclaimer' do
+    expect(page).to have_content('Provided as a suggestion only. Please verify these automated citations against the guidelines of your preferred style.')
+  end
+
+  it 'has the right headers' do
+    expect(page).to have_content('APA, 6th edition')
+    expect(page).to have_content('Chicago')
+    expect(page).to have_content('MLA')
+  end
+
+  it 'provides the right link 3 times' do
+    expect(page).to have_content('https://digital.library.emory.edu/purl/030prr4xkj-cor', count: 3)
+  end
+
+  it 'shows the APA correctly' do
+    expect(page).to have_content('Creator, S. P. (1919). Emocad. Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.')
+  end
+
+  it 'shows the Chicago Fullnote correctly' do
+    expect(page).to have_content('Creator, Sample Parent. “Emocad.” Emory University Yearbooks. Oxford, Georgia, 1919. Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.')
+  end
+
+  it 'shows the MLA correctly' do
+    expect(page).to have_content('Creator, Sample Parent. Emocad. 1919. Oxford College Library (Oxford, Ga.). https://digital.library.emory.edu/purl/030prr4xkj-cor.')
+  end
+end


### PR DESCRIPTION
1. Gemfile*: adds citeproc-ruby and csl-styles gems.
2. app/assets/stylesheets/*: styles the page to Bookmark page's standard.
3. citation_helper.rb: brings the methods defined in the formatter into the views.
4. _citation.html.erb: overrides the blacklight standard template with new helper method calls and redirected translation locations.
5. blacklight.en.yml: initiates new header translations for the citation modal.
6. citation_formatter.rb: fleshes out the logic and return methods to properly format default and CiteProc generated citations.
7. spec/*: formulates testing for both the formatter and the view.