### PR TITLE
Adds Persistent URL link to both Collection and Work views. #540

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -200,7 +200,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'subject_time_periods_tesim', label: 'Subject - Time Periods'
     config.add_show_field 'keywords_tesim', label: 'Keywords', link_to_facet: 'keywords_sim'
     # For "Find this Item" section of show page
-    # config.add_show_field 'persistent_url_tesim', label: 'Persistent URL'
+    config.add_show_field 'id', label: 'Persistent URL'
     config.add_show_field 'system_of_record_ID_tesim', label: 'System of Record ID'
     config.add_show_field 'emory_ark_tesim', label: 'Emory ARK'
     config.add_show_field 'other_identifiers_tesim', label: 'Other Identifiers'

--- a/app/presenters/find_this_item_presenter.rb
+++ b/app/presenters/find_this_item_presenter.rb
@@ -3,18 +3,13 @@
 class FindThisItemPresenter
   attr_reader :document, :config
 
-  def initialize(document:, solr_document:)
+  def initialize(document:)
     @document = document
     @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata', 'find_this_item.yml')))
-    @solr_document = solr_document
   end
 
   def terms
     @config = @config.symbolize_keys
     @document.slice(*@config.keys)
-  end
-
-  def purl
-    "https://digital.library.emory.edu/purl/#{@solr_document[:id]}"
   end
 end

--- a/app/presenters/find_this_item_presenter.rb
+++ b/app/presenters/find_this_item_presenter.rb
@@ -3,13 +3,18 @@
 class FindThisItemPresenter
   attr_reader :document, :config
 
-  def initialize(document:)
+  def initialize(document:, solr_document:)
     @document = document
     @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata', 'find_this_item.yml')))
+    @solr_document = solr_document
   end
 
   def terms
     @config = @config.symbolize_keys
     @document.slice(*@config.keys)
+  end
+
+  def purl
+    "https://digital.library.emory.edu/purl/#{@solr_document[:id]}"
   end
 end

--- a/app/views/catalog/_find_this_item.html.erb
+++ b/app/views/catalog/_find_this_item.html.erb
@@ -1,1 +1,1 @@
-<%= render 'metadata_block', document: document, presenter: FindThisItemPresenter, presenter_class: 'find-this-item', title: 'Find This Item', add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
+<%= render 'find_this_item_block', document: document, presenter: FindThisItemPresenter, presenter_class: 'find-this-item', title: 'Find This Item', add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>

--- a/app/views/catalog/_find_this_item_block.html.erb
+++ b/app/views/catalog/_find_this_item_block.html.erb
@@ -1,6 +1,5 @@
 <% doc_presenter = show_presenter(document) %>
-<% pres = presenter.new(document: doc_presenter.fields_to_render, solr_document: document) %>
-<% fields = pres.terms %>
+<% fields = presenter.new(document: doc_presenter.fields_to_render).terms %>
 <% if fields.length > 0 %>
   <div class="<%= presenter_class %> card mb-2 rounded-0">
     <div class="card-header rounded-0"><%= title %></div>
@@ -12,7 +11,7 @@
               <%= render_document_show_field_label document, field: field_name %></dt>
             <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
               <%= doc_presenter.field_value field unless field_name == "id" %>
-              <%= link_to pres.purl, pres.purl if field_name == "id" %>
+              <%= link_to "https://digital.library.emory.edu/purl/#{document["id"]}", "https://digital.library.emory.edu/purl/#{document["id"]}" if field_name == "id" %>
             </dd>
           </div>
         <% end %>

--- a/app/views/catalog/_find_this_item_block.html.erb
+++ b/app/views/catalog/_find_this_item_block.html.erb
@@ -1,0 +1,22 @@
+<% doc_presenter = show_presenter(document) %>
+<% pres = presenter.new(document: doc_presenter.fields_to_render) %>
+<% fields = pres.terms %>
+<% if fields.length > 0 %>
+  <div class="<%= presenter_class %> card mb-2 rounded-0">
+    <div class="card-header rounded-0"><%= title %></div>
+    <div class="card-body">
+      <dl>
+        <% fields.each do |field_name, field| %>
+          <div class="row">
+            <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>">
+              <%= render_document_show_field_label document, field: field_name %></dt>
+            <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
+              <%= doc_presenter.field_value field unless field_name == "id" %>
+              <%= link_to "https://digital.library.emory.edu/purl/#{document["id"]}", "https://digital.library.emory.edu/purl/088qbzkh37-cor" if field_name == "id" %>
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_find_this_item_block.html.erb
+++ b/app/views/catalog/_find_this_item_block.html.erb
@@ -1,5 +1,5 @@
 <% doc_presenter = show_presenter(document) %>
-<% pres = presenter.new(document: doc_presenter.fields_to_render) %>
+<% pres = presenter.new(document: doc_presenter.fields_to_render, solr_document: document) %>
 <% fields = pres.terms %>
 <% if fields.length > 0 %>
   <div class="<%= presenter_class %> card mb-2 rounded-0">
@@ -12,7 +12,7 @@
               <%= render_document_show_field_label document, field: field_name %></dt>
             <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
               <%= doc_presenter.field_value field unless field_name == "id" %>
-              <%= link_to "https://digital.library.emory.edu/purl/#{document["id"]}", "https://digital.library.emory.edu/purl/088qbzkh37-cor" if field_name == "id" %>
+              <%= link_to pres.purl, pres.purl if field_name == "id" %>
             </dd>
           </div>
         <% end %>

--- a/config/metadata/find_this_item.yml
+++ b/config/metadata/find_this_item.yml
@@ -1,3 +1,4 @@
+id: 'Persistent URL'
 system_of_record_ID_tesim: 'System of Record ID'
 emory_ark_tesim: 'Emory ARK'
 other_identifiers_tesim: 'Other Identifiers'

--- a/spec/presenters/find_this_item_presenter_spec.rb
+++ b/spec/presenters/find_this_item_presenter_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe FindThisItemPresenter do
-  let(:pres) { described_class.new(document: CURATE_GENERIC_WORK, solr_document: CURATE_GENERIC_WORK) }
+  let(:pres) { described_class.new(document: CURATE_GENERIC_WORK) }
   let(:find_this_item_terms) do
     { id: '123',
       system_of_record_ID_tesim: ['System of record ID seems to be a user entered string'],
@@ -19,12 +19,6 @@ RSpec.describe FindThisItemPresenter do
     describe '#terms' do
       it 'has the correct terms' do
         expect(pres.terms).to eq(find_this_item_terms)
-      end
-    end
-
-    describe '#purl' do
-      it 'produces the right persistent url string' do
-        expect(pres.purl).to eq("https://digital.library.emory.edu/purl/123")
       end
     end
   end

--- a/spec/presenters/find_this_item_presenter_spec.rb
+++ b/spec/presenters/find_this_item_presenter_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe FindThisItemPresenter do
   let(:pres) { described_class.new(document: CURATE_GENERIC_WORK) }
   let(:find_this_item_terms) do
-    { system_of_record_ID_tesim: ['System of record ID seems to be a user entered string'],
+    { id: '123',
+      system_of_record_ID_tesim: ['System of record ID seems to be a user entered string'],
       emory_ark_tesim: ['This is a legacy Emory ARK ID'],
       other_identifiers_tesim: ['oclc:(OCoLC)772049332', 'barcode:050000087509'],
       institution_tesim: ['Emory University'],

--- a/spec/presenters/find_this_item_presenter_spec.rb
+++ b/spec/presenters/find_this_item_presenter_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe FindThisItemPresenter do
-  let(:pres) { described_class.new(document: CURATE_GENERIC_WORK) }
+  let(:pres) { described_class.new(document: CURATE_GENERIC_WORK, solr_document: CURATE_GENERIC_WORK) }
   let(:find_this_item_terms) do
     { id: '123',
       system_of_record_ID_tesim: ['System of record ID seems to be a user entered string'],
@@ -19,6 +19,12 @@ RSpec.describe FindThisItemPresenter do
     describe '#terms' do
       it 'has the correct terms' do
         expect(pres.terms).to eq(find_this_item_terms)
+      end
+    end
+
+    describe '#purl' do
+      it 'produces the right persistent url string' do
+        expect(pres.purl).to eq("https://digital.library.emory.edu/purl/123")
       end
     end
   end

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "View a Work", type: :system, js: false do
     expect(page).to have_content('Keywords:')
 
     # Find This Item
+    expect(page).to have_content('Persistent URL:')
     expect(page).to have_content('System of Record ID:')
     expect(page).to have_content('Emory ARK:')
     expect(page).to have_content('Other Identifiers:')
@@ -153,6 +154,7 @@ RSpec.describe "View a Work", type: :system, js: false do
     expect(page).to have_content('words')
 
     # Find This Item
+    expect(page).to have_content("https://digital.library.emory.edu/purl/123")
     expect(page).to have_content('System of record ID seems to be a user entered string')
     expect(page).to have_content('This is a legacy Emory ARK ID')
     expect(page).to have_content('oclc:(OCoLC)772049332')


### PR DESCRIPTION
1. catalog_controller.rb: ensures that the "id" key/value gets populated in view.
2. _find_this_item.html.erb: changes render call to the new custom partial listed below.
3. find_this_item.yml: includes id and it's label in fields for the presenter to digest.
4. _find_this_item_block.html.erb: copies from metadata block but adds logic that formats the PURL correctly.
5. spec*: adds test elements for the new metadata link.