### PR TITLE
Adjusts styling to properly display titles with special characters an…

### DIFF
--- a/app/assets/stylesheets/lux/_breadcrumbs.scss
+++ b/app/assets/stylesheets/lux/_breadcrumbs.scss
@@ -1,23 +1,25 @@
 @import 'lux/variables';
 
 div.breadcrumbs-container {
-  margin-top: $search-form-margin-x;
+  margin: $search-form-margin-x 0;
 }
 
 .breadcrumbs-crumb a {
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: contents;
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
   text-decoration: none;
   cursor: pointer;
 }
+
 .breadcrumbs-crumb a::after {
   content: attr(data-subtext);
-  display: block;
+  display: contents;
 }
+
 .breadcrumbs-crumb a .icon {
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
@@ -33,11 +35,12 @@ div.breadcrumbs-container {
 .breadcrumbs {
   display: -webkit-box;
   display: -ms-flexbox;
-  display: flex;
+  display: contents;
   list-style-type: none;
   padding: 0;
   margin: $bread-crumb-margin 0 0 0;
 }
+
 .breadcrumbs-crumb + .breadcrumbs-crumb::before {
   content: "›";
   margin-left: $bread-crumb-margin;
@@ -47,11 +50,15 @@ div.breadcrumbs-container {
 .breadcrumbs-crumb {
   font-size: $bread-crumb-font-size !important;
   line-height: 1.4 !important;
+  display: contents;
+  margin-left: $bread-crumb-margin;
 }
+
 .breadcrumbs-crumb + .breadcrumbs-crumb::before {
   color: $bread-light-blue;
   font-weight: bold;
 }
+
 .breadcrumbs-crumb a {
   font-weight: bold;
   font-style: normal;
@@ -61,30 +68,38 @@ div.breadcrumbs-container {
   background: none;
   border: none;
 }
+
 .breadcrumbs-crumb a .icon {
   margin-right: 1ex;
 }
+
 .breadcrumbs-crumb a .icon,
 .breadcrumbs-crumb a .icon svg {
   width: $h4-font-size;
   height: $h4-font-size;
 }
+
 .breadcrumbs-crumb a .icon svg {
   fill: $bread-light-blue;
 }
+
 .breadcrumbs-crumb a:hover, .breadcrumbs-crumb a.is-hover, .breadcrumbs-crumb a:focus, .breadcrumbs-crumb a.is-focus {
   color: $mid-blue;
   text-decoration: none;
 }
+
 .breadcrumbs-crumb a:hover .icon svg, .breadcrumbs-crumb a.is-hover .icon svg, .breadcrumbs-crumb a:focus .icon svg, .breadcrumbs-crumb a.is-focus .icon svg {
   fill: $mid-blue;
 }
+
 .breadcrumbs-crumb a:active, .breadcrumbs-crumb a.is-active {
   color: $mid-blue;
 }
+
 .breadcrumbs-crumb a:active .icon svg, .breadcrumbs-crumb a.is-active .icon svg {
   fill: $mid-blue;
 }
+
 .breadcrumbs-crumb a::after {
   font: italic normal $font-size-base/1.9375 $font-family-sans-serif;
   letter-spacing: normal;
@@ -94,6 +109,7 @@ div.breadcrumbs-container {
   font-size: $bread-font-size-after !important;
   line-height: 1 !important;
 }
+
 .breadcrumbs-crumb a.-popular {
   font: normal normal $font-size-base-serif/2.05 $font-family-serif;
   letter-spacing: normal;
@@ -103,12 +119,15 @@ div.breadcrumbs-container {
   font-size: $font-size-lg !important;
   color: $white;
 }
+
 .breadcrumbs-crumb a.-popular:hover, .breadcrumbs-crumb a.-popular.is-hover, .breadcrumbs-crumb a.-popular:focus, .breadcrumbs-crumb a.-popular.is-focus {
   color: $bright-blue;
 }
+
 .breadcrumbs-crumb a.-popular:active, .breadcrumbs-crumb a.-popular.is-active {
   color: $bright-blue;
 }
+
 .breadcrumbs-crumb a.-underline {
   text-decoration: underline;
 }

--- a/app/views/catalog/_breadcrumbs.html.erb
+++ b/app/views/catalog/_breadcrumbs.html.erb
@@ -1,19 +1,17 @@
-<div class="container breadcrumbs-container">
-  <div class="row">
-    <nav aria-label="breadcrumb">
-      <ul class="breadcrumbs">
-        <li class="breadcrumbs-crumb"><a href="/" class="link" id="crumb">Home</a></li>
-        <% crumb_hashes.each do |c| %>
-          <li class="breadcrumbs-crumb">
-            <%= link_to c[:abbr] || c[:title], c[:link], 
-                  class: "link#{' current-page' if c[:curr_page]}",
-                  id: "crumb", 
-                  onMouseover: "this.text='#{c[:title]}'",
-                  onMouseOut: "this.text='#{c[:abbr] || c[:title]}'"
-            %>
-          </li>
-        <% end %>
-      </ul>
-    </nav>
-  </div>
+<div class="breadcrumbs-container">
+  <nav aria-label="breadcrumb">
+    <ul class="breadcrumbs">
+      <li class="breadcrumbs-crumb"><a href="/" class="link" id="crumb">Home</a></li>
+      <% crumb_hashes.each do |c| %>
+        <li class="breadcrumbs-crumb">
+          <%= link_to c[:abbr] || c[:title], c[:link], 
+                class: "link#{' current-page' if c[:curr_page]}",
+                id: "crumb", 
+                onMouseover: "this.text=\"#{c[:title]}\"",
+                onMouseOut: "this.text=\"#{c[:abbr] || c[:title]}\""
+          %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
 </div>


### PR DESCRIPTION
…d wraps long titles to next line when hovered on.

1. _breadcrumbs.scss: updates css to limit the space taken by each breadcrumb to it's contents.
2. _breadcrumbs.html.erb: escapes the wrapping quotation marks to enforce that all punctuation is displayed correctly.