### PR TITLE
Brings list of links from above Emory logo to under it.

### DIFF
--- a/app/assets/stylesheets/lux/_navbar.scss
+++ b/app/assets/stylesheets/lux/_navbar.scss
@@ -73,6 +73,10 @@ a.nav-link.last {
   border-bottom-style: solid;
 }
 
+.utility-nav {
+  margin-bottom: map-get($spacers, 2);
+}
+
 @media (min-width: 768px) { 
   .navbar-collapse.utility-nav.collapse { display: none !important; }
   .non-collapse-navbar {

--- a/app/assets/stylesheets/lux/_navbar.scss
+++ b/app/assets/stylesheets/lux/_navbar.scss
@@ -68,7 +68,22 @@ a.nav-link.last {
   padding-right: 0 !important;
 }
 
-.utility-nav {
+.utility-nav, .non-collapse-navbar {
   border: $navbar-border-width $navbar-border-color;
   border-bottom-style: solid;
+}
+
+@media (min-width: 768px) { 
+  .navbar-collapse.utility-nav.collapse { display: none !important; }
+  .non-collapse-navbar {
+    display: flex;
+    flex-basis: auto;
+    flex-grow: 1;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+@media (max-width: 767px) { 
+  .non-mobile-links { display: none !important; }
 }

--- a/app/views/shared/_big_nav.html.erb
+++ b/app/views/shared/_big_nav.html.erb
@@ -20,6 +20,7 @@
 <button class="navbar-toggler my-auto" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
   <span class="navbar-toggler-icon"></span>
 </button>
+<%= render 'shared/top_links' %>
 <% # Don't show regular search on advanced search page %>
 <div class="form-inline col-lg-8 col-md-12 col-sm-12" id="search-form">
   <% unless request.original_fullpath == "/advanced" %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -2,8 +2,11 @@
 
 <nav class="navbar navbar-expand-md navbar-light mx-auto">
   <div class="col-md-12">
-    <div class="row">
-      <%= render 'shared/top_links' %>
+    <div class="row non-mobile-links">
+      <div class="non-collapse-navbar">
+        <%= render 'shared/static_links' %>
+        <%= render 'shared/user_util_links' %>
+      </div>
     </div>
     <div class="row justify-content-between">
       <%= render 'shared/big_nav' %>

--- a/app/views/shared/_static_links.html.erb
+++ b/app/views/shared/_static_links.html.erb
@@ -1,0 +1,5 @@
+<ul class="navbar-nav">
+  <li class="nav-item"><%= link_to "Home", root_path, class: "nav-link" %></li>
+  <li class="nav-item"><%= link_to "About Digital Collections", about_path, class: "nav-link" %></li>
+  <li class="nav-item"><%= link_to "Contact", contact_path, class: "nav-link last" %></li>
+</ul>

--- a/app/views/shared/_top_links.html.erb
+++ b/app/views/shared/_top_links.html.erb
@@ -1,8 +1,4 @@
 <div class="collapse navbar-collapse utility-nav justify-content-between" id="user-util-collapse">
-  <ul class="navbar-nav">
-    <li class="nav-item"><%= link_to "Home", root_path, class: "nav-link" %></li>
-    <li class="nav-item"><%= link_to "About Digital Collections", about_path, class: "nav-link" %></li>
-    <li class="nav-item"><%= link_to "Contact", contact_path, class: "nav-link last" %></li>
-  </ul>
+  <%= render 'shared/static_links' %>
   <%= render 'shared/user_util_links' %>
 </div>

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right fields for All Fields target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'all_fields_advanced', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -152,7 +152,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right fields for Title target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'title', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -170,7 +170,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right fields for Creator target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'creator', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -186,7 +186,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Subject - Topics target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'subject_topics', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -201,7 +201,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Subject - Names target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'subject_names', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -216,7 +216,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Subject - Geographic Locations target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'subject_geo', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -231,7 +231,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Subject - Time Periods target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'subject_time_periods', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -246,7 +246,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Keywords target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'keywords', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -261,7 +261,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Table of Contents target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'table_of_contents', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -276,7 +276,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Description / Abstract target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'abstract', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -291,7 +291,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Publisher target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'publisher', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -306,7 +306,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Genre target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'content_genres', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -321,7 +321,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Note target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'notes', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -336,7 +336,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Author Notes target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'author_notes', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -351,7 +351,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Grant / Funding Information target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'grant_information_notes', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -366,7 +366,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Technical Note target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'technical_note', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -381,7 +381,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Data Source Notes target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'data_source_notes', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -396,7 +396,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches the right field for Related Material target' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for something
     fill_in 'related_material_notes', with: 'iMCnR6E8'
     click_on 'advanced-search-submit'
@@ -411,7 +411,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'searches multiple fields at once' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     # Search for two fields
     fill_in 'title', with: '2Hvw5Q55'
     fill_in 'publisher', with: '3Guv4P44'
@@ -427,13 +427,13 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: fa
 
   it 'does not display simple search bar' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     expect(page).to have_no_css('.search-query-form')
   end
 
   it 'does not display facets' do
     visit root_path
-    click_on "Advanced Search"
+    click_link("Advanced Search", match: :first)
     expect(page).to have_no_css('.limit-criteria')
   end
 end


### PR DESCRIPTION
1. _navbar.scss: adds styling to hide and show different lists when resized.
2. _big_nav.html.erb: inserts the collapsible links below the button.
3. _header_navbar.html.erb: utilizes newly created partial for static links and classes that assist in hiding top list.
4. _static_links.html.erb: throws often used links into a partial.
5. _top_links.html.erb: creates a partial that encapsulates the two sets of links into a collapsible bootstrap element.
6. advanced_search_spec.rb: points to first link of Advanced Search, since Capybara can only ignore tags that have an inline style of "display:none"