### PR TITLE
Swaps out green for our base blue on active facets #574.

### DIFF
--- a/app/assets/stylesheets/lux/_facets.scss
+++ b/app/assets/stylesheets/lux/_facets.scss
@@ -23,10 +23,12 @@
 }
 
 .facet-limit-active {
-  @extend .border-success;
+  background-color: $base-blue;
 
   .card-header {
-    @extend .bg-success;
+    background-color: $base-blue;
+
+    > button { color: $white; }
   }
 }
 
@@ -47,7 +49,7 @@
     font-size: $facet-label-font-size;
     line-height: $facet-label-line-height;
     .selected {
-      @extend .text-success;
+      color: $base-blue;
       font-weight: $font-weight-bold;
 
       &.facet-count {


### PR DESCRIPTION
1. _facets.scss: removes the extension of bootstraps standard facet colors.