### PR TITLE
Reduces the top margin of facet container on search results page #576.

### DIFF
--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -125,7 +125,7 @@ $facet-line-height:           1.5rem;
 
 $facet-label-font-size:       $font-size-base * 0.9375;
 $facet-label-line-height:     $facet-label-font-size * 1.2;
-$facet-top-margin:            2rem;
+$facet-top-margin:            $search-form-margin-x;
 
 // Explore Collections Cards
 

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -125,7 +125,7 @@ $facet-line-height:           1.5rem;
 
 $facet-label-font-size:       $font-size-base * 0.9375;
 $facet-label-line-height:     $facet-label-font-size * 1.2;
-$facet-top-margin:            $search-form-margin-x;
+$facet-top-margin:            0.3125rem;
 
 // Explore Collections Cards
 


### PR DESCRIPTION
1. _variables.scss: cuts the amount of top margin to 5pxs.