### PR TITLE
Optimizes mobile view alignment for pagination and facet toggler #578.

### DIFF
--- a/app/assets/stylesheets/lux/_facets.scss
+++ b/app/assets/stylesheets/lux/_facets.scss
@@ -102,6 +102,11 @@
   }
 }
 
+#facets-toggler {
+  position: absolute;
+  left: $facet-toggler-position;
+}
+
 // The following rules are selectively brought in
 // and adapted from Blacklight's _bootstrap_overrides.scss
 

--- a/app/assets/stylesheets/lux/_sort_widgets.scss
+++ b/app/assets/stylesheets/lux/_sort_widgets.scss
@@ -2,6 +2,14 @@
 
 div#sortAndPerPage {
   margin-bottom: $branding-padding-x;
+  justify-content: space-between;
+  margin-left: 5px;
+  margin-right: 5px;
+
+  > .sort-tools {
+    margin-left: auto;
+    right: 0;
+  }
 
   > div.sort-tools > div.per-page-dropdown, div#sort-dropdown {
     > button.dropdown-toggle {

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -127,6 +127,8 @@ $facet-label-font-size:       $font-size-base * 0.9375;
 $facet-label-line-height:     $facet-label-font-size * 1.2;
 $facet-top-margin:            2rem;
 
+$facet-toggler-position:      13.438rem;
+
 // Explore Collections Cards
 
 $explore-collections-title-font-size:       $font-size-base * 1.375;

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -6,7 +6,7 @@
       <% h2_title = request.fullpath != '/' ? "Limit Your Search" : t('blacklight.search.facets.title') %>
       <%= groupname.blank? ? h2_title : t("blacklight.search.facets-#{groupname}.title") %>
     </h2>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-controls="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-expanded="false" aria-label="Toggle facets">
+    <button class="navbar-toggler navbar-toggler-right" id="facets-toggler" type="button" data-toggle="collapse" data-target="#facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-controls="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-expanded="false" aria-label="Toggle facets">
       <span class="navbar-toggler-icon"></span>
     </button>
   </div>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,8 +1,8 @@
 <div id="sortAndPerPage" class="row sort-pagination clearfix<%= ' bookmarks' if request.fullpath == '/bookmarks' %>">
-  <div class="col-lg-6">
+  <div class="col-xs-6">
     <%= render partial: "paginate_compact", object: @response if show_pagination? %>
   </div>
-  <div class="col-lg-6 sort-tools" align="right">
+  <div class="col-xs-6 sort-tools" align="right">
     <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
   </div>
 </div>


### PR DESCRIPTION
1. _facets.scss: adds rule to position toggler closer to the header.
2. _sort_widgets.scss: provides appropriate spacing and location for the 2 buttons.
3. _variables.scss: assigns rem values to variables.
4. _facet_group.html.erb: inserts id to reference in scss.
5. _sort_and_per_page.html.erb: changes column breakpoints.