### PR TITLE
Aligns document's title to the left #584.

### DIFF
--- a/app/assets/stylesheets/lux/_show_heading.scss
+++ b/app/assets/stylesheets/lux/_show_heading.scss
@@ -5,5 +5,5 @@ h1.show-header {
   text-transform: none;
   letter-spacing: normal;
   color: $dark-blue;
-  text-align: center;
+  text-align: left;
 }


### PR DESCRIPTION
1. _show_heading.scss: chaqnges text alignment to left.