### PR TITLE
Revert "Aligns Search Results numbers and headers as separate columns…

### DIFF
--- a/app/assets/stylesheets/lux/_results_list.scss
+++ b/app/assets/stylesheets/lux/_results_list.scss
@@ -4,6 +4,10 @@ h3.heading.-h3 {
   font: normal bold $h4-font-size $font-family-sans-serif;
 }
 
+span.document-counter {
+  margin-right: map-get($spacers, 4);
+}
+
 article.document > dl.row {
   margin-left: map-get($spacers, 5);
 
@@ -27,38 +31,4 @@ div.index-document-functions > form.bookmark-toggle {
 
 dt.index-field-name {
   padding-right: map-get($spacers, 2);
-}
-
-.header-row { 
-  width: 100%;
-
-  @media (min-width: 1175px) {
-    > .col-sm-11 {
-      padding-left: 0px;
-
-      > .document-title-heading {
-        padding-left: 5px;
-      }
-    } 
-  }
-
-  @media (min-width: 745px) and (max-width: 1174px) {
-    > .col-sm-11 {
-      padding-left: 10px;
-
-      > .document-title-heading {
-        padding-left: 8px;
-      }
-    } 
-  }
-
-  @media (min-width: 695px) and (max-width: 744px) {
-    > .col-sm-11 {
-      padding-left: 20px;
-
-      > .document-title-heading {
-        padding-left: 10px;
-      }
-    } 
-  }
 }

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -10,24 +10,14 @@
     <% # bookmark functions for items/docs -%>
     <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-4 col-lg-3" %>
   <% end %>
-
-  <div class="row header-row">
-    <div class="col-sm-1">
-      <h3 class="heading -h3 index_title document-title-number col-md-12">
-        <% if counter = document_counter_with_offset(document_counter) %>
-          <span class="document-counter">
-            <%= t('blacklight.search.documents.counter', counter: counter) %>
-          </span>
-        <% end %>
-      </h3>
-    </div>
-    <div class="col-sm-11">
-      <h3 class="heading -h3 index_title document-title-heading col-md-12">
-        <%= link_to_document document, counter: counter %>
-      </h3>
-    </div>
-  </div>
-  
+  <h3 class="heading -h3 index_title document-title-heading col-md-12">
+    <% if counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', counter: counter) %>
+      </span>
+    <% end %>
+    <%= link_to_document document, counter: counter %>
+  </h3>
   <div class="row col-12 document-heading-second-row">
     <% if document["member_works_count_isi"] %>
       <dd class="col-sm-8 col-lg-9 document-details"><%= display_num_members document %></dd>

--- a/spec/system/sort_results_spec.rb
+++ b/spec/system/sort_results_spec.rb
@@ -58,31 +58,48 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
 
   it 'has correct sorting behavior for Date (Newest)' do
     visit '/?q=&search_field=common_fields&sort=year_for_lux_ssi+desc%2C+title_ssort+asc'
-    expect(page).to have_content("Results\n1.\nred Apple\n2.\nYellow Banana\n3.\nOrange Carrot\n4.\nA Potato\nSelect")
+    expect(page).to have_content('1. red Apple')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. Orange Carrot')
+    expect(page).to have_content('4. A Potato')
   end
 
   it 'has correct sorting behavior for Date (Oldest)' do
     visit '/?q=&search_field=common_fields&sort=year_for_lux_ssi+asc%2C+title_ssort+asc'
-    expect(page).to have_content("Results\n1.\nOrange Carrot\n2.\nYellow Banana\n3.\nred Apple\n4.\nA Potato\nSelect")
+    expect(page).to have_content('1. Orange Carrot')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. red Apple')
+    expect(page).to have_content('4. A Potato')
   end
 
   it 'has correct sorting behavior for Creator (A-Z)' do
     visit '/?q=&search_field=common_fields&sort=creator_ssort+asc'
-    expect(page).to have_content("Results\n1.\nOrange Carrot\n2.\nYellow Banana\n3.\nred Apple\n4.\nA Potato\nSelect")
+    expect(page).to have_content('1. Orange Carrot')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. red Apple')
+    expect(page).to have_content('4. A Potato')
   end
 
   it 'has correct sorting behavior for Creator (Z-A)' do
     visit '/?q=&search_field=common_fields&sort=creator_ssort+desc'
-    expect(page).to have_content("Results\n1.\nred Apple\n2.\nYellow Banana\n3.\nOrange Carrot\n4.\nA Potato\nSelect")
+    expect(page).to have_content('1. red Apple')
+    expect(page).to have_content('2. Yellow Banana')
+    expect(page).to have_content('3. Orange Carrot')
   end
 
   it 'has correct sorting behavior for Title (A-Z)' do
     visit '/?q=&search_field=common_fields&sort=title_ssort+asc%2C+year_for_lux_ssi+desc'
-    expect(page).to have_content("Results\n1.\nOrange Carrot\n2.\nA Potato\n3.\nred Apple\n4.\nYellow Banana\nSelect")
+    expect(page).to have_content('1. Orange Carrot')
+    expect(page).to have_content('2. A Potato')
+    expect(page).to have_content('3. red Apple')
+    expect(page).to have_content('4. Yellow Banana')
   end
 
   it 'has correct sorting behavior for Title (Z-A)' do
     visit '/?q=&search_field=common_fields&sort=title_ssort+desc%2C+year_for_lux_ssi+desc'
-    expect(page).to have_content("Results\n1.\nYellow Banana\n2.\nred Apple\n3.\nA Potato\n4.\nOrange Carrot\nSelect")
+    expect(page).to have_content('1. Yellow Banana')
+    expect(page).to have_content('2. red Apple')
+    expect(page).to have_content('3. A Potato')
+    expect(page).to have_content('4. Orange Carrot')
   end
 end


### PR DESCRIPTION
… #573. (#595)"

This reverts commit 8c5c68d8b000ffaa2954dc103cb9cf87a40929be.