### PR TITLE
Change find item heading

### DIFF
--- a/app/views/catalog/_metadata_col_1.html.erb
+++ b/app/views/catalog/_metadata_col_1.html.erb
@@ -2,7 +2,8 @@
   <%= render 'is_part_of_block', document: document, presenter: MetadataPresenter, presenter_class: 'is-part-of', title: 'This item is part of:' %>
   <% if document["has_model_ssim"]&.first == "Collection" %>
     <%= render 'view_items_in_collection_block', document: document, presenter: MetadataPresenter, presenter_class: 'view-items-in-collection' %>
+    <% title_for_find_col = 'Find This Collection' %>
   <% end %>
-  <%= render 'find_this_item_block', document: document, presenter: MetadataPresenter, presenter_class: 'find-this-item', title: 'Find This Item', add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
+  <%= render 'find_this_item_block', document: document, presenter: MetadataPresenter, presenter_class: 'find-this-item', title: "#{title_for_find_col || 'Find This Item'}", add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
   <%= render 'metadata_block', document: document, presenter: RelatedMaterialPresenter, presenter_class: 'related-material', title: 'Related Material', add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
 </div>

--- a/spec/system/view_collection_spec.rb
+++ b/spec/system/view_collection_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "View a Collection", type: :system, js: false do
     expect(page).not_to have_css('.about-this-item')
     expect(page).to have_css('.is-part-of')
     expect(page).to have_content('This item is part of:')
+    expect(page).to have_content('Find This Collection')
   end
 
   it 'has a tool card with the right options' do


### PR DESCRIPTION
* This commit changes the find item heading on collection show page from `Find This Item` to `Find This Collection`

Collection show page:
![image](https://user-images.githubusercontent.com/17075287/82258183-5fe77500-9927-11ea-8627-ae33c72273a9.png)
