### PR TITLE
Breaks multiple values in date fields into separate lines #583.

### DIFF
--- a/app/helpers/additional_catalog_helper.rb
+++ b/app/helpers/additional_catalog_helper.rb
@@ -3,4 +3,18 @@ module AdditionalCatalogHelper
   def purl(doc_id)
     "https://digital.library.emory.edu/purl/#{doc_id}"
   end
+
+  def field_is_for_dates?(field_name)
+    [
+      'human_readable_date_created_tesim',
+      'human_readable_date_issued_tesim',
+      'human_readable_data_collection_dates_tesim',
+      'human_readable_conference_dates_tesim',
+      'human_readable_copyright_date_tesim'
+    ].any? { |date_field| date_field == field_name }
+  end
+
+  def dates_on_separate_lines(document, field_name)
+    document[field_name].join("<br>")
+  end
 end

--- a/app/helpers/additional_catalog_helper.rb
+++ b/app/helpers/additional_catalog_helper.rb
@@ -5,13 +5,7 @@ module AdditionalCatalogHelper
   end
 
   def field_is_for_dates?(field_name)
-    [
-      'human_readable_date_created_tesim',
-      'human_readable_date_issued_tesim',
-      'human_readable_data_collection_dates_tesim',
-      'human_readable_conference_dates_tesim',
-      'human_readable_copyright_date_tesim'
-    ].any? { |date_field| date_field == field_name }
+    field_name.include? "date"
   end
 
   def dates_on_separate_lines(document, field_name)

--- a/app/views/catalog/_about_this_collection_block.html.erb
+++ b/app/views/catalog/_about_this_collection_block.html.erb
@@ -11,7 +11,10 @@
             <% if field_name == "finding_aid_link_ssm" %>
               <dd class="blacklight-<%= field_name.parameterize %> col-md-7"><a href="<%= doc_presenter.field_value field %>">Finding Aid</a></dd>
             <% else %>
-              <dd class="blacklight-<%= field_name.parameterize %> col-md-7"><%= doc_presenter.field_value field %></dd>
+              <dd class="blacklight-<%= field_name.parameterize %> col-md-7">
+                <%= dates_on_separate_lines(document, field_name).html_safe if field_is_for_dates?(field_name) %>
+                <%= doc_presenter.field_value field if !field_is_for_dates?(field_name) %>
+              </dd>
             <% end %>
           </div>
         <% end %>

--- a/app/views/catalog/_about_this_collection_block.html.erb
+++ b/app/views/catalog/_about_this_collection_block.html.erb
@@ -12,8 +12,11 @@
               <dd class="blacklight-<%= field_name.parameterize %> col-md-7"><a href="<%= doc_presenter.field_value field %>">Finding Aid</a></dd>
             <% else %>
               <dd class="blacklight-<%= field_name.parameterize %> col-md-7">
-                <%= dates_on_separate_lines(document, field_name).html_safe if field_is_for_dates?(field_name) %>
-                <%= doc_presenter.field_value field if !field_is_for_dates?(field_name) %>
+                <% if field_is_for_dates?(field_name) %>
+                  <%= dates_on_separate_lines(document, field_name).html_safe %>
+                <% else %>
+                  <%= doc_presenter.field_value field %>
+                <% end %>
               </dd>
             <% end %>
           </div>

--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -7,8 +7,13 @@
       <dl>
         <% fields.each do |field_name, field| %>
           <div class="row">
-            <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>"><%= render_document_show_field_label document, field: field_name %></dt>
-            <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>"><%= doc_presenter.field_value field %></dd>
+            <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>">
+              <%= render_document_show_field_label document, field: field_name %>
+            </dt>
+            <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
+              <%= dates_on_separate_lines(document, field_name).html_safe if field_is_for_dates?(field_name) %>
+              <%= doc_presenter.field_value field if !field_is_for_dates?(field_name) %>
+            </dd>
           </div>
         <% end %>
       </dl>

--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -11,8 +11,11 @@
               <%= render_document_show_field_label document, field: field_name %>
             </dt>
             <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
-              <%= dates_on_separate_lines(document, field_name).html_safe if field_is_for_dates?(field_name) %>
-              <%= doc_presenter.field_value field if !field_is_for_dates?(field_name) %>
+              <% if field_is_for_dates?(field_name) %>
+                <%= dates_on_separate_lines(document, field_name).html_safe %>
+              <% else %>
+                <%= doc_presenter.field_value field %>
+              <% end %>
             </dd>
           </div>
         <% end %>

--- a/spec/helpers/additional_catalog_helper_spec.rb
+++ b/spec/helpers/additional_catalog_helper_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require './app/helpers/additional_catalog_helper'
+
+RSpec.describe AdditionalCatalogHelper, type: :helper do
+  let(:field_names) do
+    [
+      'human_readable_date_created_tesim',
+      'human_readable_date_issued_tesim',
+      'human_readable_data_collection_dates_tesim',
+      'human_readable_conference_dates_tesim',
+      'human_readable_copyright_date_tesim'
+    ]
+  end
+
+  describe "#purl" do
+    it "returns the correct url" do
+      doc_id = "123"
+      doc_id2 = "3418kprr6m-cor"
+
+      expect(helper.purl(doc_id)).to eq("https://digital.library.emory.edu/purl/123")
+      expect(helper.purl(doc_id2)).to eq("https://digital.library.emory.edu/purl/3418kprr6m-cor")
+    end
+
+    it "returns a url with no id when id nil" do
+      doc_id = ""
+
+      expect(helper.purl(doc_id)).to eq("https://digital.library.emory.edu/purl/")
+    end
+  end
+
+  describe "#field_is_for_dates?" do
+    it "returns true when field name matches" do
+      field_names.each do |field_name|
+        expect(helper.field_is_for_dates?(field_name)).to be_truthy
+      end
+    end
+
+    it "returns false when wrong field name or nil" do
+      expect(helper.field_is_for_dates?("say_what?")).to be_falsey
+      expect(helper.field_is_for_dates?("")).to be_falsey
+    end
+  end
+
+  describe "#dates_on_separate_lines" do
+    let(:date_array) do
+      [
+        "October 22, 2018 to October 25, 2018",
+        "January 1998 to May 2001",
+        "190s0s",
+        "within the 1930s or 1940s"
+      ]
+    end
+    let(:merging_hash) do
+      Hash[field_names.collect { |name| [name, date_array] }]
+    end
+    let(:merging_hash2) do
+      Hash[field_names.collect { |name| [name, [date_array.first]] }]
+    end
+    let(:document) { CHILD_CURATE_GENERIC_WORK_3.dup.merge(merging_hash) }
+    let(:document2) { CHILD_CURATE_GENERIC_WORK_3.dup.merge(merging_hash2) }
+
+    it "joins <br> between each element of the array" do
+      field_names.each do |field_name|
+        expect(dates_on_separate_lines(document, field_name).scan(/(?<=\<br\>)/).count).to eq(3)
+      end
+    end
+
+    it "inserts no <br> with only one element in the array" do
+      field_names.each do |field_name|
+        expect(dates_on_separate_lines(document2, field_name).scan(/(?<=\<br\>)/).count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. additional_catalog_helper.rb: abstracts away the test and processing for making dates fall on multiple lines.
2. _about_this_collection_block.html.erb and _metadata_block.html.erb: adds a switch to the separate line processor if a date field is detected.
3. additional_catalog_helper_spec.rb: creates a test suite for the helpers used here and previously.