### PR TITLE
Converts the lower headers of static page to 48px #586.

### DIFF
--- a/app/assets/stylesheets/lux/_static_headers.scss
+++ b/app/assets/stylesheets/lux/_static_headers.scss
@@ -40,8 +40,8 @@ div.row.static-heading-row {
 }
 
 h2.static-blurb-header {
-  font: normal normal $h4-font-size/normal $font-family-serif;
-    color: $base-blue;
-    margin-block-start: map-get($spacers, 4); 
-    margin-block-end: map-get($spacers, 3);
+  font: normal normal $h1-show-font-size/normal $font-family-serif;
+  color: $base-blue;
+  margin-block-start: map-get($spacers, 4); 
+  margin-block-end: map-get($spacers, 3);
 }


### PR DESCRIPTION
1. _static_headers.scss: matches the top header font size.