### PR TITLE
Prevents erroneous dates like "0ad" by only adding "issued" variable…

### DIFF
--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -18,7 +18,7 @@ module Emory
     end
 
     def citation_for(style)
-      sanitized_citation(CiteProc::Processor.new(style: style, format: 'html').import(item).render(:bibliography, id: :item).first)
+      sanitized_citation(CiteProc::Processor.new(style: style, format: 'html').import(item).render(:bibliography, id: :item).first, obj)
     rescue CiteProc::Error, TypeError, ArgumentError
       @default_citations[style.to_sym]
     end
@@ -26,7 +26,7 @@ module Emory
     private
 
       def item
-        CiteProc::Item.new(key_value_chunk_1.merge(key_value_chunk_2).merge(key_value_chunk_3))
+        CiteProc::Item.new(issued_inserter(key_value_chunk_1.merge(key_value_chunk_2).merge(key_value_chunk_3)))
       end
 
       def mla_url_test
@@ -61,8 +61,7 @@ module Emory
           title: obj[:title_tesim]&.join(', '),
           "collection-title": obj[:member_of_collections_ssim]&.join(', '),
           type: [obj[:human_readable_content_type_ssim]&.first&.downcase]&.join(', '),
-          url: url,
-          issued: (obj[:date_issued_tesim] || obj[:year_issued_isim] || obj[:year_created_isim] || [0])&.first&.to_i
+          url: url(obj)
         }
       end
 
@@ -76,6 +75,12 @@ module Emory
           keyword: obj[:keywords_tesim]&.join(', '),
           "publisher-place": obj[:place_of_production_tesim]&.join(', ')
         }
+      end
+
+      def issued_inserter(hsh)
+        return hsh.merge(issued: obj[:date_issued_tesim].first.to_i) if obj[:date_issued_tesim].present?
+        return hsh.merge(issued: obj[:date_created_tesim].first.to_i) if obj[:date_created_tesim].present?
+        hsh
       end
   end
 end

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -69,9 +69,13 @@ module Emory
       end
 
       def issued_inserter(hsh)
-        return hsh.merge(issued: obj[:date_issued_tesim].first.to_i) if obj[:date_issued_tesim].present?
-        return hsh.merge(issued: obj[:date_created_tesim].first.to_i) if obj[:date_created_tesim].present?
-        hsh
+        if obj[:date_issued_tesim]&.any?(&:present?)
+          hsh.merge(issued: obj[:date_issued_tesim].first.to_i)
+        elsif obj[:year_created_isim]&.any?(&:present?) && !obj[:year_created_isim].first.zero?
+          hsh.merge(issued: obj[:year_created_isim].first)
+        else
+          hsh
+        end
       end
   end
 end

--- a/lib/emory/citation_formatter.rb
+++ b/lib/emory/citation_formatter.rb
@@ -29,15 +29,6 @@ module Emory
         CiteProc::Item.new(issued_inserter(key_value_chunk_1.merge(key_value_chunk_2).merge(key_value_chunk_3)))
       end
 
-      def mla_url_test
-        [
-          obj[:holding_repository_tesim],
-          obj[:edition_tesim],
-          obj[:publisher_tesim],
-          obj[:date_issued_tesim]
-        ].any?(&:present?)
-      end
-
       def abnormal_chars?
         obj[:creator_tesim]&.any? { |a| a.match(/[^\p{L}\s]+/) }
       end
@@ -60,7 +51,7 @@ module Emory
           publisher: obj[:publisher_tesim]&.join(', '),
           title: obj[:title_tesim]&.join(', '),
           "collection-title": obj[:member_of_collections_ssim]&.join(', '),
-          type: [obj[:human_readable_content_type_ssim]&.first&.downcase]&.join(', '),
+          type: obj[:human_readable_content_type_ssim]&.first&.downcase,
           url: url(obj)
         }
       end

--- a/lib/emory/citation_string_processor.rb
+++ b/lib/emory/citation_string_processor.rb
@@ -1,60 +1,60 @@
 # frozen_string_literal: true
 
 module CitationStringProcessor
-  def url
-    "https://digital.library.emory.edu/purl/#{obj[:id]}" if obj[:id]
+  include AdditionalCatalogHelper
+
+  def url(obj)
+    purl(obj[:id]) if obj.present? && obj[:id].present?
   end
 
   def append_string_with_comma(field)
-    "#{field&.first}, " if field.present?
+    "#{field&.first}, " if field.any?(&:present?)
   end
 
   def append_string_with_period(field)
-    "#{field&.first}. " if field.present?
+    "#{field&.first}. " if field.any?(&:present?)
   end
 
-  def apa_edition
-    ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
+  def apa_edition(obj)
+    ", #{obj[:edition_tesim].first}" if obj.present? && obj[:edition_tesim].present?
   end
 
-  def sanitized_citation(citation)
-    if !citation.include?(url) && citation.last != "."
-      citation << ". #{url}."
-    elsif !citation.include?(url) && citation.last == "."
-      citation << " #{url}."
+  def sanitized_citation(citation, obj)
+    if !citation.include?(url(obj)) && citation.last != "."
+      "#{citation}. #{url(obj)}."
+    elsif !citation.include?(url(obj)) && citation.last == "."
+      "#{citation} #{url(obj)}."
     else
       citation
     end
   end
 
-  def author_name_no_period
+  def author_name_no_period(obj)
     return obj[:creator_tesim].map { |a| a.first(a.size - 1) } if obj[:creator_tesim]&.any? { |a| a&.split('')&.last == '.' }
     obj[:creator_tesim]
   end
 
   def formatted_apa_author
     return joined_apa_author_names unless abnormal_chars? || obj[:creator_tesim].blank?
-    "#{author_name_no_period&.join(', & ')}. " unless obj[:creator_tesim].blank?
+    "#{author_name_no_period(obj)&.join(', & ')}. " unless obj[:creator_tesim].blank?
   end
 
   def formatted_mla_author
     return joined_mla_author_names unless abnormal_chars? || obj[:creator_tesim].blank?
-    "#{author_name_no_period&.join(', ')}. " unless obj[:creator_tesim].blank?
+    "#{author_name_no_period(obj)&.join(', ')}. " unless obj[:creator_tesim].blank?
   end
 
   def formatted_chicago_author
-    "#{author_name_no_period&.join(', ')}, " unless author_name_no_period.nil?
+    "#{author_name_no_period(obj)&.join(', ')}, " unless author_name_no_period(obj).nil?
   end
 
   def apa_default_citation
     [
       formatted_apa_author,
-      ("(#{obj[:date_issued_tesim]&.first})" unless obj[:date_issued_tesim].nil?),
-      ("[#{obj[:title_tesim]&.first}#{apa_edition}]. " unless obj[:title_tesim].nil?),
+      apa_date_selector,
+      ("[#{obj[:title_tesim]&.first}#{apa_edition(obj)}]. " unless obj[:title_tesim].nil?),
       append_string_with_comma(obj[:member_of_collections_ssim]),
-      append_string_with_period(obj[:holding_repository_tesim]),
-      url,
-      "."
+      append_string_with_period(obj[:holding_repository_tesim]), url(obj), "."
     ].join('')
   end
 
@@ -62,10 +62,10 @@ module CitationStringProcessor
     [
       formatted_chicago_author,
       append_string_with_comma(obj[:title_tesim]),
-      append_string_with_comma(obj[:date_issued_tesim]),
+      append_string_with_comma(obj[:date_issued_tesim] || obj[:human_readable_date_created_tesim]),
       append_string_with_comma(obj[:member_of_collections_ssim]),
       append_string_with_period(obj[:holding_repository_tesim]),
-      url,
+      url(obj),
       "."
     ].join('')
   end
@@ -74,10 +74,10 @@ module CitationStringProcessor
     [
       formatted_mla_author,
       append_string_with_period(obj[:title_tesim]),
-      append_string_with_period(obj[:date_issued_tesim]),
+      append_string_with_period(obj[:date_issued_tesim] || obj[:human_readable_date_created_tesim]),
       append_string_with_period(obj[:member_of_collections_ssim]),
       append_string_with_period(obj[:holding_repository_tesim]),
-      url,
+      url(obj),
       "."
     ].join('')
   end
@@ -88,5 +88,13 @@ module CitationStringProcessor
 
   def joined_mla_author_names
     "#{obj[:creator_tesim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')}. "
+  end
+
+  def apa_date_selector
+    if obj[:date_issued_tesim].present?
+      "(#{obj[:date_issued_tesim]&.first})"
+    elsif obj[:date_issued_tesim].nil? && obj[:human_readable_date_created_tesim].present?
+      "(#{obj[:human_readable_date_created_tesim]&.first})"
+    end
   end
 end

--- a/lib/emory/citation_string_processor.rb
+++ b/lib/emory/citation_string_processor.rb
@@ -60,13 +60,10 @@ module CitationStringProcessor
 
   def chicago_default_citation
     [
-      formatted_chicago_author,
-      append_string_with_comma(obj[:title_tesim]),
+      formatted_chicago_author, append_string_with_comma(obj[:title_tesim]),
       append_string_with_comma(obj[:date_issued_tesim] || obj[:human_readable_date_created_tesim]),
       append_string_with_comma(obj[:member_of_collections_ssim]),
-      append_string_with_period(obj[:holding_repository_tesim]),
-      url(obj),
-      "."
+      append_string_with_period(obj[:holding_repository_tesim]), url(obj), "."
     ].join('')
   end
 

--- a/spec/lib/citation_formatter_spec.rb
+++ b/spec/lib/citation_formatter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Emory::CitationFormatter do
   end
 
   it 'always includes the url' do
-    url = cit_gen.send(:url)
+    url = cit_gen.send(:url, document)
 
     expect(cit_gen.citation_for(apa)).to include(url)
     expect(cit_gen.citation_for(chicago)).to include(url)

--- a/spec/lib/citation_formatter_spec.rb
+++ b/spec/lib/citation_formatter_spec.rb
@@ -78,76 +78,46 @@ RSpec.describe Emory::CitationFormatter do
   end
 
   context '#key_value_chunk_1' do
-    it "has the right keys" do
-      expect(cit_gen.send(:key_value_chunk_1).keys).to(
-        eq([:id, :abstract, :archive_location, :author, :"call-number", :edition, :institution])
-      )
-    end
+    key_arr = [:id, :abstract, :archive_location, :author, :"call-number", :edition, :institution]
+    keys_values_hsh = {
+      id: :item,
+      abstract: nil,
+      archive_location: nil,
+      author: "Sample Parent Creator",
+      "call-number": nil,
+      edition: nil,
+      institution: "Emory University"
+    }
 
-    it 'has the right values' do
-      keys_values_arr = [
-        [:id, :item],
-        [:abstract, nil],
-        [:archive_location, nil],
-        [:author, "Sample Parent Creator"],
-        [:"call-number", nil],
-        [:edition, nil],
-        [:institution, "Emory University"]
-      ]
-      cit_gen_chunk = cit_gen.send(:key_value_chunk_1)
-
-      keys_values_arr.each do |k, v|
-        expect(cit_gen_chunk[k]).to eq(v)
-      end
-    end
+    include_examples "check_citation_item_key_and_values", :key_value_chunk_1, key_arr, keys_values_hsh
   end
 
   context '#key_value_chunk_2' do
-    it "has the right keys" do
-      expect(cit_gen.send(:key_value_chunk_2).keys).to(
-        eq([:archive, :publisher, :title, :"collection-title", :type, :url])
-      )
-    end
+    key_arr = [:archive, :publisher, :title, :"collection-title", :type, :url]
+    keys_values_hsh = {
+      archive: "Oxford College Library (Oxford, Ga.)",
+      publisher: nil,
+      title: "Emocad.",
+      "collection-title": "Emory University Yearbooks",
+      type: "text",
+      url: "https://digital.library.emory.edu/purl/030prr4xkj-cor"
+    }
 
-    it 'has the right values' do
-      keys_values_arr = [
-        [:archive, "Oxford College Library (Oxford, Ga.)"],
-        [:publisher, nil],
-        [:title, "Emocad."],
-        [:"collection-title", "Emory University Yearbooks"],
-        [:type, "text"],
-        [:url, "https://digital.library.emory.edu/purl/030prr4xkj-cor"]
-      ]
-      cit_gen_chunk = cit_gen.send(:key_value_chunk_2)
-
-      keys_values_arr.each do |k, v|
-        expect(cit_gen_chunk[k]).to eq(v)
-      end
-    end
+    include_examples "check_citation_item_key_and_values", :key_value_chunk_2, key_arr, keys_values_hsh
   end
 
   context '#key_value_chunk_3' do
-    it "has the right keys" do
-      expect(cit_gen.send(:key_value_chunk_3).keys).to(
-        eq([:dimensions, :event, :genre, :ISBN, :ISSN, :keyword, :"publisher-place"])
-      )
-    end
+    key_arr = [:dimensions, :event, :genre, :ISBN, :ISSN, :keyword, :"publisher-place"]
+    keys_values_hsh = {
+      dimensions: nil,
+      event: nil,
+      genre: nil,
+      ISBN: nil,
+      ISSN: nil,
+      keyword: nil,
+      "publisher-place": "Oxford, Georgia"
+    }
 
-    it 'has the right values' do
-      keys_values_arr = [
-        [:dimensions, nil],
-        [:event, nil],
-        [:genre, nil],
-        [:ISBN, nil],
-        [:ISSN, nil],
-        [:keyword, nil],
-        [:"publisher-place", "Oxford, Georgia"]
-      ]
-      cit_gen_chunk = cit_gen.send(:key_value_chunk_3)
-
-      keys_values_arr.each do |k, v|
-        expect(cit_gen_chunk[k]).to eq(v)
-      end
-    end
+    include_examples "check_citation_item_key_and_values", :key_value_chunk_3, key_arr, keys_values_hsh
   end
 end

--- a/spec/lib/citation_formatter_spec.rb
+++ b/spec/lib/citation_formatter_spec.rb
@@ -53,4 +53,101 @@ RSpec.describe Emory::CitationFormatter do
   it "sanitizes the MLA author name correctly in default citation if it's properly formatted" do
     expect(cit_gen.default_citations[mla.to_sym]).to include('Creator, Sample Parent')
   end
+
+  context '#abnormal_chars?' do
+    it 'returns true if abnormal character is found' do
+      ab_doc = document.dup.merge(creator_tesim: ["/"])
+      ab_doc2 = document.dup.merge(creator_tesim: ["1"])
+      ab_doc3 = document.dup.merge(creator_tesim: [","])
+      cit_gennie = described_class.new(ab_doc)
+      cit_gennie2 = described_class.new(ab_doc2)
+      cit_gennie3 = described_class.new(ab_doc3)
+
+      expect(cit_gennie.send(:abnormal_chars?)).to be_truthy
+      expect(cit_gennie2.send(:abnormal_chars?)).to be_truthy
+      expect(cit_gennie3.send(:abnormal_chars?)).to be_truthy
+    end
+
+    it 'returns false if abnormal character is not found' do
+      ab_doc = document.dup.merge(creator_tesim: ["ç"])
+      cit_gennie = described_class.new(ab_doc)
+
+      expect(cit_gen.send(:abnormal_chars?)).to be_falsey
+      expect(cit_gennie.send(:abnormal_chars?)).to be_falsey
+    end
+  end
+
+  context '#key_value_chunk_1' do
+    it "has the right keys" do
+      expect(cit_gen.send(:key_value_chunk_1).keys).to(
+        eq([:id, :abstract, :archive_location, :author, :"call-number", :edition, :institution])
+      )
+    end
+
+    it 'has the right values' do
+      keys_values_arr = [
+        [:id, :item],
+        [:abstract, nil],
+        [:archive_location, nil],
+        [:author, "Sample Parent Creator"],
+        [:"call-number", nil],
+        [:edition, nil],
+        [:institution, "Emory University"]
+      ]
+      cit_gen_chunk = cit_gen.send(:key_value_chunk_1)
+
+      keys_values_arr.each do |k, v|
+        expect(cit_gen_chunk[k]).to eq(v)
+      end
+    end
+  end
+
+  context '#key_value_chunk_2' do
+    it "has the right keys" do
+      expect(cit_gen.send(:key_value_chunk_2).keys).to(
+        eq([:archive, :publisher, :title, :"collection-title", :type, :url])
+      )
+    end
+
+    it 'has the right values' do
+      keys_values_arr = [
+        [:archive, "Oxford College Library (Oxford, Ga.)"],
+        [:publisher, nil],
+        [:title, "Emocad."],
+        [:"collection-title", "Emory University Yearbooks"],
+        [:type, "text"],
+        [:url, "https://digital.library.emory.edu/purl/030prr4xkj-cor"]
+      ]
+      cit_gen_chunk = cit_gen.send(:key_value_chunk_2)
+
+      keys_values_arr.each do |k, v|
+        expect(cit_gen_chunk[k]).to eq(v)
+      end
+    end
+  end
+
+  context '#key_value_chunk_3' do
+    it "has the right keys" do
+      expect(cit_gen.send(:key_value_chunk_3).keys).to(
+        eq([:dimensions, :event, :genre, :ISBN, :ISSN, :keyword, :"publisher-place"])
+      )
+    end
+
+    it 'has the right values' do
+      keys_values_arr = [
+        [:dimensions, nil],
+        [:event, nil],
+        [:genre, nil],
+        [:ISBN, nil],
+        [:ISSN, nil],
+        [:keyword, nil],
+        [:"publisher-place", "Oxford, Georgia"]
+      ]
+      cit_gen_chunk = cit_gen.send(:key_value_chunk_3)
+
+      keys_values_arr.each do |k, v|
+        expect(cit_gen_chunk[k]).to eq(v)
+      end
+    end
+  end
 end

--- a/spec/lib/citation_string_processor_spec.rb
+++ b/spec/lib/citation_string_processor_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require './lib/emory/citation_string_processor'
+
+RSpec.describe CitationStringProcessor, type: :helper do
+  describe '#append_string_with_comma' do
+    it 'appends a comma if field present' do
+      expect(helper.append_string_with_comma(["blah"])).to eq("blah, ")
+    end
+
+    it 'returns nil if field nil' do
+      expect(helper.append_string_with_comma([""])).to be_nil
+    end
+  end
+
+  describe '#append_string_with_period' do
+    it 'appends a period if field present' do
+      expect(helper.append_string_with_period(["blah"])).to eq("blah. ")
+    end
+
+    it 'returns nil if field nil' do
+      expect(helper.append_string_with_period([""])).to be_nil
+    end
+  end
+
+  let!(:obj) { CURATE_GENERIC_WORK }
+
+  describe '#apa_edition' do
+    it 'prepends a comma and space if edition_tesim present' do
+      expect(helper.apa_edition(obj)).to eq(', 3rd ed.')
+    end
+
+    it 'returns nil if obj nil' do
+      expect(helper.apa_edition(nil)).to be_nil
+    end
+  end
+
+  describe '#sanitized_citation' do
+    let(:citation) do
+      "Central Press Photos Ltd. (London, England). Body of Malcolm X in a coffin, with mourners paying their respects. March 3, 1986. Robert Langmuir African American Photograph Collection. Stuart A. Rose Manuscript, Archives, and Rare Book Library"
+    end
+
+    it 'prepends a period, space, and url if url not present with no ending period' do
+      expect(helper.sanitized_citation(citation, obj)).to eq(citation + ". https://digital.library.emory.edu/purl/123.")
+    end
+
+    it 'prepends a space and url if url not present with ending period' do
+      expect(helper.sanitized_citation(citation.dup.concat("."), obj)).to eq(citation + ". https://digital.library.emory.edu/purl/123.")
+    end
+
+    it 'returns citation if url present' do
+      expect(helper.sanitized_citation(citation.dup.concat(". https://digital.library.emory.edu/purl/123."), obj)).to(
+        eq(citation + ". https://digital.library.emory.edu/purl/123.")
+      )
+    end
+  end
+
+  describe '#author_name_no_period' do
+    it "eliminates period if one exists at end of creator_tesim" do
+      expect(helper.author_name_no_period(obj.dup.merge(creator_tesim: ["John Doe Bradley."]))).to(
+        eq(["John Doe Bradley"])
+      )
+    end
+
+    it "passes through creator_tesims that have no period at the end" do
+      expect(helper.author_name_no_period(obj.dup.merge(creator_tesim: ["John Doe Bradley"]))).to(
+        eq(["John Doe Bradley"])
+      )
+    end
+  end
+end

--- a/spec/lib/citation_string_processor_spec.rb
+++ b/spec/lib/citation_string_processor_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe CitationStringProcessor, type: :helper do
       expect(helper.append_string_with_comma(["blah"])).to eq("blah, ")
     end
 
-    it 'returns nil if field nil' do
+    it 'returns nil if field empty string' do
       expect(helper.append_string_with_comma([""])).to be_nil
+    end
+
+    it 'returns nil if field nil' do
+      expect(helper.append_string_with_comma([nil])).to be_nil
     end
   end
 
@@ -18,12 +22,17 @@ RSpec.describe CitationStringProcessor, type: :helper do
       expect(helper.append_string_with_period(["blah"])).to eq("blah. ")
     end
 
-    it 'returns nil if field nil' do
+    it 'returns nil if field empty string' do
       expect(helper.append_string_with_period([""])).to be_nil
+    end
+
+    it 'returns nil if field nil' do
+      expect(helper.append_string_with_period([nil])).to be_nil
     end
   end
 
   let!(:obj) { CURATE_GENERIC_WORK }
+  let!(:alt_obj) { CHILD_CURATE_GENERIC_WORK_1 }
 
   describe '#apa_edition' do
     it 'prepends a comma and space if edition_tesim present' do
@@ -32,6 +41,10 @@ RSpec.describe CitationStringProcessor, type: :helper do
 
     it 'returns nil if obj nil' do
       expect(helper.apa_edition(nil)).to be_nil
+    end
+
+    it 'returns nil if obj has no edition_tesim field' do
+      expect(helper.apa_edition(alt_obj)).to be_nil
     end
   end
 

--- a/spec/support/shared_examples_for_citation_formatter.rb
+++ b/spec/support/shared_examples_for_citation_formatter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "check_citation_item_key_and_values" do |method, key_arr, keys_values_hsh|
+  it "has the right keys" do
+    expect(cit_gen.send(method).keys).to eq(key_arr)
+  end
+
+  it 'has the right values' do
+    cit_gen_chunk = cit_gen.send(method)
+
+    expect(cit_gen_chunk).to eq(keys_values_hsh)
+  end
+end


### PR DESCRIPTION
…to citeproc gem when date is available.

Also bolsters citation processor testing and refactors based on additional testing.
1. citation_formatter.rb: adds new method that inserts "issued" when right fields are present.
2. citation_string_processor.rb: refactors methods for error proofing and reusability.
3. citation_formatter_spec.rb: swaps out calls to new ones with arguments.
4. citation_string_processor_spec.rb: creates new spec to test methods that did not already have them.