### PR TITLE
Defeats errors caused buy .any? testing on nil.

### DIFF
--- a/lib/emory/citation_string_processor.rb
+++ b/lib/emory/citation_string_processor.rb
@@ -8,11 +8,11 @@ module CitationStringProcessor
   end
 
   def append_string_with_comma(field)
-    "#{field&.first}, " if field.any?(&:present?)
+    "#{field&.first}, " if field&.any?(&:present?)
   end
 
   def append_string_with_period(field)
-    "#{field&.first}. " if field.any?(&:present?)
+    "#{field&.first}. " if field&.any?(&:present?)
   end
 
   def apa_edition(obj)


### PR DESCRIPTION
1. lib/emory/citation_string_processor.rb: adds andand protection to `.any?` to protest against unexpected field values.