### PR TITLE
Corrects "Unknown" limiter path and constraint logic #611. 

### DIFF
--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module RenderConstraintsHelper
+  include BlacklightAdvancedSearch::RenderConstraintsOverride
+
+  # query_has_constraints? overridden from RenderConstraintsOverride to include :range
+  def query_has_constraints?(localized_params = params)
+    if is_advanced_search? localized_params
+      true
+    else
+      !(localized_params[:q].blank? && localized_params[:f].blank? && localized_params[:range].blank? && localized_params[:f_inclusive].blank?)
+    end
+  end
+
+  def missing_constraint_url(field_name)
+    search_action_url(add_range_missing(field_name))
+  end
+
+  def missing_constraint_url_corrected(field_name)
+    missing_url = missing_constraint_url(field_name)
+    if missing_url.include?("&search_field=common_fields")
+      missing_url
+    else
+      "#{missing_url}&search_field=common_fields"
+    end
+  end
+end

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -88,7 +88,7 @@
         <ul class="missing list-unstyled facet-values subsection">
           <li>
             <span class="facet-label">
-              <%= link_to t('blacklight.range_limit.missing'), search_action_url(add_range_missing(field_name).except(:controller, :action)) %>
+              <%= link_to t('blacklight.range_limit.missing'), missing_constraint_url_corrected(field_name) %>
             </span>
             <%# note important there be no whitespace inside facet-count to avoid
                 bug in some versions of Blacklight (including 7.1.0.alpha) %>

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -67,4 +67,25 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     expect(page).to have_content('Newt Nutrition')
     expect(page).to have_content('Eagle Excellence')
   end
+
+  describe 'when "unknown" limiter is clicked' do
+    context 'on homepage' do
+      it "provides a constraint on the next page" do
+        visit root_path
+        click_on "Unknown"
+
+        expect(page).to have_content('Remove constraint Date: Unknown')
+      end
+    end
+
+    context 'on search results page' do
+      it "provides a constraint on the next page" do
+        visit root_path
+        click_on 'search'
+        click_on "Unknown"
+
+        expect(page).to have_content('Remove constraint Date: Unknown')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- render_constraints_helper.rb: initiates override of `query_has_constraints?` to include `:range` and adds two more needed methods.
- _range_limit_panel.html.erb: swaps out link for method call that corrects the unknown limiter's parameters.
- facet_by_year_spec.rb: bolsters the testing for facet_by_year.