### PR TITLE
Adds timeout duration for devise

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -176,7 +176,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 24.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
* Sometimes even though a user is authenticated through shib, their devise cookie might have expired which leads to the Lux app assuming that the user has logged out, that leads to some broken thumbnails. We are setting the devise user session timeout config to 24 hours to avoid this. After this duration the user will be asked to login again.

In case our solution here doesn't work there is another gem that handles devise session timeouts: https://github.com/pelargir/auto-session-timeout

Connected to #561 