### PR TITLE
Adds description meta tag for better SEO (#621).

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -13,6 +13,7 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <%= tag.meta name: 'description', content: t('blacklight.meta.description') %>
 
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -27,6 +27,8 @@ en:
       logout: 'Log Out'
       bookmarks: 'Bookmarks'
       search_history: 'History'
+    meta: 
+      description: 'The digital front door to the unique cultural heritage and scholarship material from Emory Libraries. Discover, view, and download images, books, and more from our campus repositories.'
     search:
       facets:
         title: 'Browse All Items'

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -3,10 +3,20 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'front page', type: :system do
+  before do
+    visit '/'
+  end
+
   it 'has featured collections' do
-    visit "/"
     expect(page).to have_content 'Health Sciences Center Library Artifact Collection'
     expect(page).to have_content 'Robert Langmuir African American Photograph Collection'
     expect(page).to have_content 'Oxford College Collection of Asian Artifacts'
+  end
+
+  it 'has a meta description tag' do
+    expect(page).to have_css(
+      'meta[name="description"][content="The digital front door to the unique cultural heritage and scholarship material from Emory Libraries. Discover, view, and download images, books, and more from our campus repositories."]',
+      visible: false
+    )
   end
 end


### PR DESCRIPTION
- base.html.erb: inserts the meta tag into the homepage.
- blacklight.en.yml: adds the description into localization.
- front_page_spec.rb: creates a test to check its existence.