### PR TITLE
Changes verbiage on search history page (#627).

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -21,6 +21,10 @@ en:
 
   blacklight:
     application_name: 'Emory Digital Collections'
+    citation:
+      apa: 'APA, 6th edition'
+      chicago-fullnote-bibliography: 'Chicago'
+      modern-language-association: 'MLA'
     header_links:
       advanced_search: 'Advanced Search'
       login: 'Login'
@@ -35,7 +39,5 @@ en:
       form:
         search:
           placeholder: 'Search Digital Collections'
-    citation:
-      apa: 'APA, 6th edition'
-      chicago-fullnote-bibliography: 'Chicago'
-      modern-language-association: 'MLA'
+    search_history:
+      recent: 'Your recent searches (cleared after your browser session)'

--- a/spec/system/view_search_history_spec.rb
+++ b/spec/system/view_search_history_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'viewing search history', type: :system do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([COLLECTION, PARENT_CURATE_GENERIC_WORK])
+    solr.commit
+  end
+
+  context 'after searching in the catalog' do
+    it 'has right subheader' do
+      visit "/"
+      fill_in 'q', with: "Emocad"
+      click_on('search')
+      visit '/search_history'
+
+      expect(page).to have_content('Your recent searches (cleared after your browser session)')
+    end
+  end
+end


### PR DESCRIPTION
- config/locales/blacklight.en.yml: overrides gem locale translation.
- spec/*: tests for right text.