### PR TITLE
Updates the verbiage on the not found page (#550).

### DIFF
--- a/app/views/static/not_found.html.erb
+++ b/app/views/static/not_found.html.erb
@@ -2,22 +2,8 @@
     <%= render 'catalog/breadcrumbs', crumb_hashes: [] %>
     <div class="row static-heading-row not-found">
       <%= render 'static/static_heading', 
-              title: "Page Not Available", 
-              subheading: "You may have reached this page due to an incorrect address, or because the item you are trying to view has specific access restrictions. Use your browser's back button or return <a href='/' class='static-blurb-link'>home</a> to continue. For more assistance, <a href='/contact' class='static-blurb-link'>contact us</a>.".html_safe
+              title: t('static.not_found.header'), 
+              subheading: t('static.not_found.subheading').html_safe
       %>
-    </div>
-    <div class="row static-body not-found">
-      <%= render 'static/static_content_blurbs', 
-                    blurb_header_klass: " accessing-blurb-header col-12",
-                    blurb_header: "Accessing Emory Digital Collections",
-                    blurb_body_klass: " accessing-blurb col-12",
-                    blurb: "Some items in Emory Digital Collections are restricted."
-      %>
-      <ul class="not-found-list">
-        <li class="not-found-list-item">Items marked "Log In Required" are limited to those with an Emory University login.</li>
-        <li class="not-found-list-item">A limited number of objects can be viewed only in the Rose Library reading room. Contact the <a href="mailto:rose.library@emory.edu" class='static-blurb-link'>Rose Library via email</a> for more information.</li>
-        <li class="not-found-list-item">Some items may no longer be available from the providing library. Refer to the contact information for each digital collection and also consult our <a href='/contact' class='static-blurb-link'>Contact</a> page.</li>
-        <li class="not-found-list-item">Additional information is available within our user guide at <a href="https://wiki.service.emory.edu/display/DLPP/Emory+Digital+Collections+User+Guide" class='static-blurb-link'>our wiki site</a>.</li>
-      </ul>
     </div>
 </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -21,6 +21,10 @@ en:
 
   blacklight:
     application_name: 'Emory Digital Collections'
+    citation:
+      apa: 'APA, 6th edition'
+      chicago-fullnote-bibliography: 'Chicago'
+      modern-language-association: 'MLA'
     header_links:
       advanced_search: 'Advanced Search'
       login: 'Login'
@@ -35,10 +39,8 @@ en:
       form:
         search:
           placeholder: 'Search Digital Collections'
-    citation:
-      apa: 'APA, 6th edition'
-      chicago-fullnote-bibliography: 'Chicago'
-      modern-language-association: 'MLA'
+    search_history:
+      recent: 'Your recent searches (cleared after your browser session)'
 
   static:
     not_found:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -39,3 +39,8 @@ en:
       apa: 'APA, 6th edition'
       chicago-fullnote-bibliography: 'Chicago'
       modern-language-association: 'MLA'
+
+  static:
+    not_found:
+      header: 'Page Not Found'
+      subheading: "You may have reached this page due to an incorrect address. Use your browser's back button or return <a href='/' class='static-blurb-link'>home</a> to continue. For more assistance, <a href='/contact' class='static-blurb-link'>contact us</a>."

--- a/spec/requests/not_found_spec.rb
+++ b/spec/requests/not_found_spec.rb
@@ -15,15 +15,31 @@ RSpec.describe "404 Error Custom Page", type: :request do
   it "contains the requested headers" do
     get "/1q"
 
-    expect(response.body).to include 'Page Not Available'
-    expect(response.body).to include 'Accessing Emory Digital Collections'
-    expect(response.body).to include 'mailto:rose.library@emory.edu'
-    expect(response.body).to include 'our wiki site'
-    expect(response.body).to include 'https://wiki.service.emory.edu/display/DLPP/Emory+Digital+Collections+User+Guide'
+    expect(response.body).to include 'Page Not Found'
+    expect(response.body).not_to include 'Accessing Emory Digital Collections'
+    expect(response.body).not_to include 'mailto:rose.library@emory.edu'
+    expect(response.body).not_to include 'our wiki site'
+    expect(response.body).not_to include 'https://wiki.service.emory.edu/display/DLPP/Emory+Digital+Collections+User+Guide'
+  end
+
+  it "contains the requested links" do
+    get "/1q"
+
+    expect(response.body).not_to include 'mailto:rose.library@emory.edu'
+    expect(response.body).not_to include 'our wiki site'
+    expect(response.body).not_to include 'https://wiki.service.emory.edu/display/DLPP/Emory+Digital+Collections+User+Guide'
   end
 
   it "loads the page for unlogged in users looking for bookmarks" do
     get "/bookmarks"
     expect(response.status).to eq 404
+  end
+
+  it 'contains the right verbiage' do
+    get "/1q"
+
+    expect(response.body).to include 'You may have reached this page due to an incorrect address.'
+    expect(response.body).to include "Use your browser's back button or return"
+    expect(response.body).to include 'to continue. For more assistance,'
   end
 end

--- a/spec/system/show_page_visibility_spec.rb
+++ b/spec/system/show_page_visibility_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(emory_high_work_id)
       expect(page).not_to have_content 'Work with Emory High visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
 
       # Should see (low res) page content
       visit solr_document_path(public_low_view_work_id)
@@ -65,17 +65,17 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(emory_low_work_id)
       expect(page).not_to have_content 'Work with Emory Low visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
 
       # Should not see page content
       visit solr_document_path(rose_high_work_id)
       expect(page).not_to have_content 'Work with Rose High View visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
 
       # Should not see page content
       visit solr_document_path(private_work_id)
       expect(page).not_to have_content 'Work with Private visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
     end
   end
 
@@ -105,12 +105,12 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(rose_high_work_id)
       expect(page).not_to have_content 'Work with Rose High View visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
 
       # Should not see page content
       visit solr_document_path(private_work_id)
       expect(page).not_to have_content 'Work with Private visibility'
-      expect(page).to have_content 'Page Not Available'
+      expect(page).to have_content 'Page Not Found'
     end
   end
 end

--- a/spec/system/view_search_history_spec.rb
+++ b/spec/system/view_search_history_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'viewing search history', type: :system do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([COLLECTION, PARENT_CURATE_GENERIC_WORK])
+    solr.commit
+  end
+
+  context 'after searching in the catalog' do
+    it 'has right subheader' do
+      visit "/"
+      fill_in 'q', with: "Emocad"
+      click_on('search')
+      visit '/search_history'
+
+      expect(page).to have_content('Your recent searches (cleared after your browser session)')
+    end
+  end
+end


### PR DESCRIPTION
- app/views/static/not_found.html.erb: swaps out hardcoded text with localizations. Also removes "Accessing" tutorial.
- config/locales/blacklight.en.yml: defines localization for not found page headers and text.
- spec/* : changes and improves expectations for new verbiage.