### PR TITLE
Displays resolution and download warnings based on visibility (#628).

### DIFF
--- a/app/assets/stylesheets/lux/_cards.scss
+++ b/app/assets/stylesheets/lux/_cards.scss
@@ -8,3 +8,4 @@ div.card-header {
   color: $gold;
 }
 
+.resolution-download-restriction { font-weight: $font-weight-bold }

--- a/app/views/catalog/_about_this_item_block.html.erb
+++ b/app/views/catalog/_about_this_item_block.html.erb
@@ -4,6 +4,15 @@
   <div class="<%= presenter_class %> card mb-2 rounded-0">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
+      <% if document['visibility_ssi'] == 'low_res' %>
+        <p class="resolution-download-restriction">
+          <%= t('blacklight.work.about_this_item.low_resolution') %> <%= t('blacklight.work.about_this_item.downloads') %>
+        </p>
+      <% elsif document['visibility_ssi'] == 'emory_low' %>
+        <p class="resolution-download-restriction">
+          <%= t('blacklight.work.about_this_item.low_resolution') %>
+        </p>
+      <% end %>
       <dl>
         <% fields.each do |field_name, field| %>
           <div class="row">

--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -4,6 +4,15 @@
   <div class="<%= presenter_class %> card mb-2 rounded-0">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
+      <% if presenter == AboutThisItemPresenter && document['visibility_ssi'] == 'low_res' %>
+        <p class="resolution-download-restriction">
+          <%= t('blacklight.work.about_this_item.low_resolution') %> <%= t('blacklight.work.about_this_item.downloads') %>
+        </p>
+      <% elsif presenter == AboutThisItemPresenter && document['visibility_ssi'] == 'emory_low' %>
+        <p class="resolution-download-restriction">
+          <%= t('blacklight.work.about_this_item.low_resolution') %>
+        </p>
+      <% end %>
       <dl>
         <% fields.each do |field_name, field| %>
           <div class="row">

--- a/app/views/catalog/_metadata_col_2.html.erb
+++ b/app/views/catalog/_metadata_col_2.html.erb
@@ -4,7 +4,7 @@
   <% end %>
   <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
     <%= render 'this_item_contains_block', document: document, presenter: ThisItemContainsPresenter, presenter_class: 'this-item-contains', title: 'This item contains:' %>
-    <%= render 'metadata_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
+    <%= render 'about_this_item_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
   <% end %>
   <%= render 'metadata_block', document: document, presenter: SubjectsKeywordsPresenter, presenter_class: 'subjects-keywords', title: 'Subjects / Keywords', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
   <%= render 'metadata_block', document: document, presenter: PublicationDetailsPresenter, presenter_class: 'publication-details', title: 'Publication Details', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -45,3 +45,9 @@ en:
       about_this_item:
         downloads: 'Downloads are not permitted for this material.'
         low_resolution: 'This item is provided at low resolution only.'
+
+  static:
+    not_found:
+      header: 'Page Not Found'
+      subheading: "You may have reached this page due to an incorrect address. Use your browser's back button or return <a href='/' class='static-blurb-link'>home</a> to continue. For more assistance, <a href='/contact' class='static-blurb-link'>contact us</a>."
+

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -41,3 +41,7 @@ en:
           placeholder: 'Search Digital Collections'
     search_history:
       recent: 'Your recent searches (cleared after your browser session)'
+    work:
+      about_this_item:
+        downloads: 'Downloads are not permitted for this material.'
+        low_resolution: 'This item is provided at low resolution only.'


### PR DESCRIPTION
- app/assets/stylesheets/lux/_cards.scss: styles the warnings.
- app/views/catalog/_metadata_block.html.erb: inserts logic to fire off warnings.
- config/locales/blacklight.en.yml: makes the text localization calls.
- spec/system/show_page_visibility_spec.rb: tests the delivery of the warnings.