### PR TITLE
Moves search result elements around (#626).

### DIFF
--- a/app/assets/stylesheets/lux/_results_list.scss
+++ b/app/assets/stylesheets/lux/_results_list.scss
@@ -9,7 +9,7 @@ span.document-counter {
 }
 
 article.document > dl.row {
-  margin-left: map-get($spacers, 5);
+  margin-left: map-get($spacers, 0);
 
   > dt {
     padding-left: $navbar-padding-y
@@ -21,14 +21,21 @@ dd.document-details {
 }
 
 div.document-heading-second-row {
-  margin-left: $results-document-head-margin;
-  padding-right: $results-document-head-margin;
+  margin-left: map-get($spacers, 0);
 }
 
-div.index-document-functions > form.bookmark-toggle {
-  text-align: right;
+div.index-document-functions > .bookmark-toggle {
+  width: max-content;
 }
 
 dt.index-field-name {
   padding-right: map-get($spacers, 2);
+}
+
+.document-thumbnail > a > img {
+  width: $results-thumbnail-width;
+}
+
+.documents-list > .document {
+  margin-bottom: $results-document-bottom-margin;
 }

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -176,12 +176,11 @@ $bread-container-margin-top:         0.75rem;
 $bread-container-margin-bottom:      1rem;
 
 // Search Results
-$results-sort-min-height:            $search-form-height * 2;
 $results-border-radius:              0;
-$results-box-position:               $results-border-radius;
 $results-drop-menu-min-w:            4.063rem;
-$results-document-head-margin:       2.2rem;
 $results-pagination-margin:          0.563rem;
+$results-thumbnail-width:            11.5rem;
+$results-document-bottom-margin:     2rem;
 
 // Static
 $static-explorer-head-letter-space:     0.038rem;

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,9 +1,13 @@
 <% doc_presenter = index_presenter(document) %>
+<% document_actions = capture do %>
+  <% # bookmark functions for items/docs -%>
+  <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-4 col-lg-3" %>
+<% end %>
 <%# default partial to display solr document fields in catalog index view -%>
 
 <dl class="row">
   <dt class="col-sm-3"><%= render_document_partials document, [:thumbnail] %></dt>
-  <dd class="col-sm-9">
+  <dd class="col-sm-6">
     <dl>
       <% doc_presenter.fields_to_render.each do |field_name, field| -%>
         <div class="row">
@@ -12,5 +16,8 @@
         </div>
       <% end -%>
     </dl>
+  </dd>
+  <dd class="col-sm-3">
+    <%= document_actions %>
   </dd>
 </dl>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -6,28 +6,23 @@
       How many bootstrap columns need to be reserved
       for bookmarks control depends on size.
   -%>
-  <% document_actions = capture do %>
-    <% # bookmark functions for items/docs -%>
-    <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-4 col-lg-3" %>
-  <% end %>
   <h3 class="heading -h3 index_title document-title-heading col-md-12">
     <% if counter = document_counter_with_offset(document_counter) %>
       <span class="document-counter">
         <%= t('blacklight.search.documents.counter', counter: counter) %>
-      </span>
+      </span><br>
     <% end %>
     <%= link_to_document document, counter: counter %>
   </h3>
   <div class="row col-12 document-heading-second-row">
     <% if document["member_works_count_isi"] %>
-      <dd class="col-sm-8 col-lg-9 document-details"><%= display_num_members document %></dd>
+      <dd class="document-details"><%= display_num_members document %></dd>
     <% elsif document["child_works_for_lux_tesim"] %>
-      <dd class="col-sm-8 col-lg-9 document-details"><%= display_num_children document %></dd>
+      <dd class="document-details"><%= display_num_children document %></dd>
     <% elsif document["parent_work_for_lux_tesim"] %>
-      <dd class="col-sm-8 col-lg-9 document-details">Part of: <%= link_to_parent_work document %></dd>
+      <dd class="document-details">Part of: <%= link_to_parent_work document %></dd>
     <% else %>
-      <dd class="col-sm-8 col-lg-9 document-details"></dd>
+      <dd class="document-details"></dd>
     <% end %>
-    <%= document_actions %>
   </div>
 </header>


### PR DESCRIPTION
- app/assets/stylesheets/lux/_results_list.scss: alters and adds styling to configure the results page correctly.
- app/assets/stylesheets/lux/_variables.scss: cleans up and adds new variables for search results.
- app/views/catalog/_index.html.erb: inserts bookmark checkbox into the lower row of the result item.
- app/views/catalog/_index_header.html.erb: puts the list number on it's own line and removes the bookmark checkbox from the top header.