### PR TITLE
Redirect unauthenticated users to login page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,7 +8,13 @@ class CatalogController < ApplicationController
   rescue_from NameError, with: :render_404
 
   def render_404
-    render file: Rails.root.join('app', 'views', 'static', 'not_found.html.erb'), status: :not_found, layout: true
+    visibility = visibility_lookup(resource_id_param)
+    case visibility
+    when 'emory_low', 'authenticated'
+      redirect_to new_user_session_path
+    else
+      render file: Rails.root.join('app', 'views', 'static', 'not_found.html.erb'), status: :not_found, layout: true
+    end
   end
 
   # Apply the blacklight-access_controls

--- a/spec/requests/visibility_request_spec.rb
+++ b/spec/requests/visibility_request_spec.rb
@@ -74,13 +74,15 @@ RSpec.describe "Visibility requests", :clean, type: :request do
       it "does not load the 'show' page for a work with 'Emory High Download' visibility" do
         get "/catalog/#{emory_high_work_id}"
 
-        expect(response.status).to eq 404
+        # Should redirect to login page
+        expect(response.status).to eq 302
       end
 
       it "does not load the 'show' page for a work with 'Emory Low Download' visibility" do
         get "/catalog/#{emory_low_work_id}"
 
-        expect(response.status).to eq 404
+        # Should redirect to login page
+        expect(response.status).to eq 302
       end
 
       it "does not load the 'show' page for a work with 'Rose High View' visibility" do

--- a/spec/system/search_results_visibility_spec.rb
+++ b/spec/system/search_results_visibility_spec.rb
@@ -85,14 +85,42 @@ RSpec.describe "View search results for works with different levels of visibilit
 
   context "as an unauthenticated user" do
     context 'when searching for an Emory Low Download work' do
-      it 'has a generic "Please Login for Access" thumbnail' do
+      before do
         visit "/"
         fill_in 'q', with: emory_low_work_id
         click_on('search')
+      end
+
+      it 'has a generic "Please Login for Access" thumbnail' do
         expect(page).to have_css('.document-thumbnail')
         expect(page).to have_link('Thumbnail image')
         expect(page.find("img.img-fluid")['outerHTML']).to match(/login-required/)
         expect(page).not_to have_css("img[src='http://obviously_fake_url.com/downloads/#{emory_low_work_id}?file=thumbnail']")
+      end
+
+      it 'redirects to the login page when user tries to view Emory Low Download work' do
+        click_on('Thumbnail image')
+        expect(current_path).to eq(new_user_session_path)
+      end
+    end
+
+    context 'when searching for an Emory High Download work' do
+      before do
+        visit "/"
+        fill_in 'q', with: emory_high_work_id
+        click_on('search')
+      end
+
+      it 'has a generic "Please Login for Access" thumbnail' do
+        expect(page).to have_css('.document-thumbnail')
+        expect(page).to have_link('Thumbnail image')
+        expect(page.find("img.img-fluid")['outerHTML']).to match(/login-required/)
+        expect(page).not_to have_css("img[src='http://obviously_fake_url.com/downloads/#{emory_high_work_id}?file=thumbnail']")
+      end
+
+      it 'redirects to the login page when user tries to view Emory High Download work' do
+        click_on('Thumbnail image')
+        expect(current_path).to eq(new_user_session_path)
       end
     end
   end

--- a/spec/system/show_page_visibility_spec.rb
+++ b/spec/system/show_page_visibility_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(emory_high_work_id)
       expect(page).not_to have_content 'Work with Emory High visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(current_path).to eq(new_user_session_path)
 
       # Should see (low res) page content
       visit solr_document_path(public_low_view_work_id)
@@ -65,7 +65,7 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(emory_low_work_id)
       expect(page).not_to have_content 'Work with Emory Low visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(current_path).to eq(new_user_session_path)
 
       # Should not see page content
       visit solr_document_path(rose_high_work_id)


### PR DESCRIPTION
- When a non-logged-in user tries to view a work that is login required, they are redirected to the login page