### PR TITLE
Removes code declaring date (#554).

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -79,7 +79,7 @@
     <% end %>
 
     <%= link_to t('blacklight.range_limit.view_larger', field_name: label),
-        range_limit_panel_url(id: field_name, range_start: 0, range_end: 2019),
+        range_limit_panel_url(id: field_name),
         class: 'view_larger mt-1',
         data: { blacklight_modal: 'trigger' } %>
 


### PR DESCRIPTION
- app/views/blacklight_range_limit/_range_limit_panel.html.erb: this completely strips out the start and end of the range boundaries because the gem itself seems hard coded to only rely on solr's stat attribute from the ajax response, no matter what those arguments are set to.