### PR TITLE
Add 404 page for reading room/private works

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -12,6 +12,8 @@ class CatalogController < ApplicationController
     case visibility
     when 'emory_low', 'authenticated'
       redirect_to new_user_session_path
+    when 'rose_high', 'restricted'
+      render file: Rails.root.join('app', 'views', 'static', 'reading_room_not_found.html.erb'), status: :not_found, layout: true
     else
       render file: Rails.root.join('app', 'views', 'static', 'not_found.html.erb'), status: :not_found, layout: true
     end

--- a/app/views/static/reading_room_not_found.html.erb
+++ b/app/views/static/reading_room_not_found.html.erb
@@ -1,0 +1,15 @@
+<div class="container not-found-container">
+    <%= render 'catalog/breadcrumbs', crumb_hashes: [] %>
+    <div class="row static-heading-row not-found">
+      <%= render 'static/static_heading', 
+              title: t('static.reading_room_not_found.header'), 
+              subheading: t('static.reading_room_not_found.subheading').html_safe
+      %>
+    </div>
+    <%= render 'static/static_content_blurbs', 
+                    blurb_header_klass: " reading-room-blurb-header",
+                    blurb_header: "More About Access Restrictions",
+                    blurb_body_klass: " reading-room-blurb",
+                    blurb: "<ul><li>Some items may no longer be available from the providing library. Refer to the contact information for each digital collection or consult our <a href='/contact' class='static-blurb-link'>Contact</a> page</li><li>Additional information is available within our user guide at <a href='https://wiki.service.emory.edu/display/DLPP/Emory+Digital+Collections+User+Guide' class='static-blurb-link'>our wiki site</a>.</li></ul>".html_safe
+    %>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -50,3 +50,6 @@ en:
     not_found:
       header: 'Page Not Found'
       subheading: "You may have reached this page due to an incorrect address. Use your browser's back button or return <a href='/' class='static-blurb-link'>home</a> to continue. For more assistance, <a href='/contact' class='static-blurb-link'>contact us</a>."
+    reading_room_not_found:
+      header: 'Reading Room Only'
+      subheading: "This item is accessible only onsite. Contact the <a href='mailto:rose.library@emory.edu' class='static-blurb-link'>Rose Library via email</a> for more information. Use your browser's back button or return <a href='/' class='static-blurb-link'>home</a> to continue browsing Digital Collections. For more assistance, <a href='/contact' class='static-blurb-link'>contact us</a>."

--- a/spec/system/show_page_visibility_spec.rb
+++ b/spec/system/show_page_visibility_spec.rb
@@ -88,12 +88,12 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(rose_high_work_id)
       expect(page).not_to have_content 'Work with Rose High View visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(page).to have_content 'Reading Room Only'
 
       # Should not see page content
       visit solr_document_path(private_work_id)
       expect(page).not_to have_content 'Work with Private visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(page).to have_content 'Reading Room Only'
     end
   end
 
@@ -123,12 +123,12 @@ RSpec.describe "View Works with different levels of visibility", type: :system d
       # Should not see page content
       visit solr_document_path(rose_high_work_id)
       expect(page).not_to have_content 'Work with Rose High View visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(page).to have_content 'Reading Room Only'
 
       # Should not see page content
       visit solr_document_path(private_work_id)
       expect(page).not_to have_content 'Work with Private visibility'
-      expect(page).to have_content 'Page Not Found'
+      expect(page).to have_content 'Reading Room Only'
     end
   end
 


### PR DESCRIPTION
- When a user tries to view a reading room only object outside the reading room or a private object, they are taken to a new 404 page with information about those specific access restrictions