### PR TITLE
Adjusts y-axis transformation to keep titles front and center (#608).

### DIFF
--- a/app/assets/stylesheets/lux/_hero_image.scss
+++ b/app/assets/stylesheets/lux/_hero_image.scss
@@ -5,25 +5,65 @@
 .intro-hero-title {
   position: relative;
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateY(50%);
 
   font-family: $font-family-serif;
   font-weight: $font-weight-bold;
-  font-size: $hero-title-font-size;
+  font-size: $font-size-lg;
 }
+
 .intro-hero-text {
+  font: normal bold $font-size-sm $font-family-sans-serif;
   position: relative;
-  transform: translateY(-185%);
+  transform: translateY(90%);
 }
+
+@media (min-width: 400px) {
+  .intro-hero-title {
+    transform: translateY(35%);
+  }
+
+  .intro-hero-text {
+    transform: translateY(25%);
+  }
+}
+
+@include media-breakpoint-up(sm) {
+  .intro-hero-title {
+    transform: translateY(-50%);
+    font-size: $hero-title-font-size;
+  }
+
+  .intro-hero-text {
+    font: normal bold $font-size-base $font-family-sans-serif;
+    position: relative;
+    transform: translateY(-75%);
+  }
+}
+
 @include media-breakpoint-up(md) {
   .intro-hero-title {
-    font-size: $hero-title-font-size-large;
+    font-size: $hero-title-font-size-md;
+    transform: translateY(-125%);
+  }
+
+  .intro-hero-text {
+    font: normal bold $font-size-base $font-family-sans-serif;
+    position: relative;
+    transform: translateY(-300%);
   }
 }
 
 @include media-breakpoint-up(lg) {
   .intro-hero-title {
-    transform: translateY(-100%);
+    font-size: $hero-title-font-size-large;
+    transform: translateY(-150%);
+  }
+
+  .intro-hero-text {
+    font: normal bold $hero-title-font-size $font-family-sans-serif;
+    position: relative;
+    transform: translateY(-225%);
   }
 }
 

--- a/app/assets/stylesheets/lux/_variables.scss
+++ b/app/assets/stylesheets/lux/_variables.scss
@@ -119,6 +119,7 @@ $search-form-button-padding-x:      1.5625rem;
 // Hero Image
 
 $hero-title-font-size:                $font-size-base * 1.75;
+$hero-title-font-size-md:             $font-size-base * 2.5;
 $hero-title-font-size-large:          $font-size-base * 3.125;
 $hero-bottom-margin:                  2.063rem;
 

--- a/app/views/catalog/_hero_image.html.erb
+++ b/app/views/catalog/_hero_image.html.erb
@@ -3,7 +3,7 @@
 <div class="carousel slide mt-3 mb-3" data-ride="carousel" data-interval="6000">
   <div class="carousel-caption">
     <h1 class="intro-hero-title">Emory Digital Collections</h1>
-    <h3 class="intro-hero-text heading -h3">Access unique research materials</h3>
+    <h3 class="intro-hero-text">Access unique research materials</h3>
   </div>
   <div class="carousel-inner">
     <div class="carousel-item active">


### PR DESCRIPTION
- app/assets/stylesheets/lux/_hero_image.scss: expands out the styling of the Hero Image title for a wider array of screen sizes.
- app/assets/stylesheets/lux/_variables.scss: adds a new font size to the variables list.
- app/views/catalog/_hero_image.html.erb: takes away a limiting styling class.