### PR TITLE
Embeds additional browse links on homepage

### DIFF
--- a/app/assets/stylesheets/lux/_facets.scss
+++ b/app/assets/stylesheets/lux/_facets.scss
@@ -136,3 +136,12 @@
 section#sidebar.search {
   margin-top: $facet-top-margin;
 }
+
+.browse-link {
+  color: $base-blue;
+  
+  &:hover {
+    color: $bright-blue;
+    text-decoration: none;
+  }
+}

--- a/app/views/catalog/_explore_collections.html.erb
+++ b/app/views/catalog/_explore_collections.html.erb
@@ -1,7 +1,7 @@
 <% presenter = ExploreCollectionsPresenter.new %>
 <% collections = presenter.collections %>
 <div class="homepage-content-header">
-  <h2 class="homepage-content-heading explore-collections-heading">Explore Our Collections</h2>
+  <h2 class="homepage-content-heading explore-collections-heading"><%= link_to 'Explore Our Collections', search_action_path('f[has_model_ssim][]' => 'Collection'), class: "browse-link" %></h2>
 </div>
 <div class="tiles row justify-content-between">
   <% collections.each do |c| %>

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -4,7 +4,11 @@
   <div class="navbar navbar-light navbar-expand-lg">
     <h2 class="homepage-content-heading">
       <% h2_title = request.fullpath != '/' ? "Limit Your Search" : t('blacklight.search.facets.title') %>
-      <%= groupname.blank? ? h2_title : t("blacklight.search.facets-#{groupname}.title") %>
+      <% if h2_title == t('blacklight.search.facets.title') && groupname.blank? %>
+        <%= link_to h2_title, search_action_path(:utf8 => '✓', :search_field => 'common_fields', :q => ''), method: :get, class: "browse-link" %>
+      <% else %>
+        <%= groupname.blank? ? h2_title : t("blacklight.search.facets-#{groupname}.title") %>
+      <% end %>
     </h2>
     <button class="navbar-toggler navbar-toggler-right" id="facets-toggler" type="button" data-toggle="collapse" data-target="#facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-controls="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-expanded="false" aria-label="Toggle facets">
       <span class="navbar-toggler-icon"></span>

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe 'front page', type: :system do
       visible: false
     )
   end
+
+  it 'has Explore Our Collections hyperlink', js: true do
+    expect(page).to have_link('Explore Our Collections')
+  end
 end


### PR DESCRIPTION
Browse all items when hovered upon:
![image](https://user-images.githubusercontent.com/17075287/87377303-f916be80-c559-11ea-80b4-5a616a1e9677.png)

Link click output:
Will run a blank search

Explore Our Collections when hovered upon:
![image](https://user-images.githubusercontent.com/17075287/87377635-18155080-c55a-11ea-90e4-652f975abe8e.png)

Link click output:
Will run a search to list all collections in the repo
![image](https://user-images.githubusercontent.com/17075287/87377741-4dba3980-c55a-11ea-9cb8-c58bed44fe70.png)
