### PR TITLE
Adds timeoutable hook to devise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   # Include devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   # remove :database_authenticatable in production, remove :validatable to integrate with Shibboleth
-  devise_modules = [:omniauthable, :rememberable, :trackable, omniauth_providers: [:shibboleth], authentication_keys: [:uid]]
+  devise_modules = [:omniauthable, :rememberable, :trackable, :timeoutable, omniauth_providers: [:shibboleth], authentication_keys: [:uid]]
   devise_modules.prepend(:database_authenticatable) if AuthConfig.use_database_auth?
   devise(*devise_modules)
 


### PR DESCRIPTION
* We are adding the timeoutable module to devise so that it can use the timeout config defined in devise initializer.
Refer: https://github.com/emory-libraries/dlp-lux/blob/master/config/initializers/devise.rb#L176