### PR TITLE
Make search form scripts compatible with Turbolinks

### DIFF
--- a/app/assets/javascripts/fielded_search_dropdown.js
+++ b/app/assets/javascripts/fielded_search_dropdown.js
@@ -1,5 +1,6 @@
 // Retrigger the fielded search dropdown after navigating the site
 // through turbolinks
-$(document).on('turbolinks:load', function() {
+
+$(document).on('ready turbolinks:load', function() {
   $(window).trigger('load.bs.select.data-api');
 });

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only sr-only-focusable"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
-  <div class="input-group col-md-12">
+  <div id="search-fields" class="input-group col-md-12" data-turbolinks-permanent>
     <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
                        options_for_select(search_fields, h(params[:search_field])),


### PR DESCRIPTION
- Previously, when loading a page from the Turbolinks cache, the script responsible for the fielded search dropdown would be re-triggered and append a duplicate dropdown below the existing one (see [Lux issue 632](https://github.com/emory-libraries/dlp-lux/issues/632)). Now, using the `data-turbolinks-permanent` attribute from the Turbolinks API ([Persisting Elements Across Page Loads](https://github.com/turbolinks/turbolinks#persisting-elements-across-page-loads)), the entire search form persists across page loads, whether from a normal render or a cache render.