### PR TITLE
Converts document-heading-second-row into a dl (#655).

### DIFF
--- a/app/assets/stylesheets/lux/_results_list.scss
+++ b/app/assets/stylesheets/lux/_results_list.scss
@@ -20,8 +20,9 @@ dd.document-details {
   margin-right: $navbar-padding-y
 }
 
-div.document-heading-second-row {
+dl.document-heading-second-row {
   margin-left: map-get($spacers, 0);
+  margin-bottom: map-get($spacers, 0);
 }
 
 div.index-document-functions > .bookmark-toggle {

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -14,7 +14,7 @@
     <% end %>
     <%= link_to_document document, counter: counter %>
   </h3>
-  <div class="row col-12 document-heading-second-row">
+  <dl class="row col-12 document-heading-second-row">
     <% if document["member_works_count_isi"] %>
       <dd class="document-details"><%= display_num_members document %></dd>
     <% elsif document["child_works_for_lux_tesim"] %>
@@ -24,5 +24,5 @@
     <% else %>
       <dd class="document-details"></dd>
     <% end %>
-  </div>
+  </dl>
 </header>

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -76,4 +76,14 @@ RSpec.feature "View Search Results", type: :system, js: false do
       find("img[src='http://obviously_fake_url.com/iiif/825x69p8dh-cor/thumbnail']")
     end
   end
+
+  context 'screen reader readability' do
+    it 'wraps document-details row in a dl' do
+      visit "/"
+      fill_in 'q', with: simple_work_id
+      click_on('search')
+
+      expect(page).to have_css('dl.document-heading-second-row')
+    end
+  end
 end


### PR DESCRIPTION
- app/assets/stylesheets/lux/_results_list.scss: points to `dl` instead of `div` and adjusts `dl`'s inherent bottom margin.
- app/views/catalog/_index_header.html.erb: swaps out to `div`.
- spec/system/view_search_results_spec.rb: adds test that checks for `dl` wrapper.