### PR TITLE
Change color of View Collection

### DIFF
--- a/app/assets/stylesheets/lux/_explore_collections.scss
+++ b/app/assets/stylesheets/lux/_explore_collections.scss
@@ -92,6 +92,6 @@
   font-weight: $font-weight-bold;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: $alt-bright-blue;
+  color: $bright-blue;
   transition: $link-hover-transition;
 }


### PR DESCRIPTION
- The text color of "View Collection" on the homepage collection cards is now accessible (Emory's bright blue #336BE6)
<img width="351" alt="Screen Shot 2020-07-23 at 9 33 02 AM" src="https://user-images.githubusercontent.com/46227821/88292473-ab235880-ccc7-11ea-934d-b2a80942a118.png">
