### PR TITLE
Improves accessibility with titles reflecting card headers (#656).

### DIFF
--- a/app/helpers/about_this_item_helper.rb
+++ b/app/helpers/about_this_item_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module AboutThisItemHelper
+  def resolution_download_restriction(document)
+    if document['visibility_ssi'] == 'low_res'
+      "<p class='resolution-download-restriction'>
+        #{t('blacklight.work.about_this_item.low_resolution')} #{t('blacklight.work.about_this_item.downloads')}
+      </p>"
+    elsif document['visibility_ssi'] == 'emory_low'
+      "<p class='resolution-download-restriction'>
+        #{t('blacklight.work.about_this_item.low_resolution')}
+      </p>"
+    end
+  end
+end

--- a/app/helpers/find_this_item_helper.rb
+++ b/app/helpers/find_this_item_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module FindThisItemHelper
+  def find_item_field_label(document, field_name)
+    render_document_show_field_label document, field: field_name
+  end
+
+  def find_item_field_value(doc_presenter, field, field_name)
+    return doc_presenter.field_value field unless field_name == "id"
+    link_to purl(doc_presenter.field_value(field)), purl(doc_presenter.field_value(field))
+  end
+end

--- a/app/views/catalog/_about_this_collection_block.html.erb
+++ b/app/views/catalog/_about_this_collection_block.html.erb
@@ -1,10 +1,10 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms(:about_this_collection) %>
 <% if fields.length > 0 %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <dl>
+      <dl title="<%= title %>">
         <% fields.each do |field_name, field| %>
           <div class="row">
             <dt class="blacklight-<%= field_name.parameterize %> col-md-5"><%= render_document_show_field_label document, field: field_name %></dt>

--- a/app/views/catalog/_about_this_item_block.html.erb
+++ b/app/views/catalog/_about_this_item_block.html.erb
@@ -1,19 +1,11 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms %>
 <% if fields.length > 0 %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <% if document['visibility_ssi'] == 'low_res' %>
-        <p class="resolution-download-restriction">
-          <%= t('blacklight.work.about_this_item.low_resolution') %> <%= t('blacklight.work.about_this_item.downloads') %>
-        </p>
-      <% elsif document['visibility_ssi'] == 'emory_low' %>
-        <p class="resolution-download-restriction">
-          <%= t('blacklight.work.about_this_item.low_resolution') %>
-        </p>
-      <% end %>
-      <dl>
+      <%= resolution_download_restriction(document)&.html_safe %>
+      <dl title="<%= title %>">
         <% fields.each do |field_name, field| %>
           <div class="row">
             <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>">

--- a/app/views/catalog/_access_and_copyright_block.html.erb
+++ b/app/views/catalog/_access_and_copyright_block.html.erb
@@ -1,10 +1,10 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms(:access_and_copyright) %>
 <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <dl>
+      <dl title="<%= title %>">
         <dt class="blacklight-emory_rights_statement">Rights Statement:</dt>
         <dd class="blacklight-emory_rights_statement"><%= document["emory_rights_statements_tesim"]&.first %></dd>
         <dt class="blacklight-rights_statement">Rights Status:</dt>
@@ -19,7 +19,7 @@
           <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
           <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
         <% end %>
-          <p class="copyright-dislaimer">Emory Libraries provides copyright information as a courtesy and makes no representation about copyright or other legal status of materials in its digital collections.</p>
+          <p class="copyright-dislaimer" title="copyright dislaimer">Emory Libraries provides copyright information as a courtesy and makes no representation about copyright or other legal status of materials in its digital collections.</p>
       </dl>
     </div>
   </div>

--- a/app/views/catalog/_find_this_item_block.html.erb
+++ b/app/views/catalog/_find_this_item_block.html.erb
@@ -1,17 +1,16 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms(:find_this_item) %>
 <% if fields.length > 0 %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <dl>
+      <dl title="<%= title %>">
         <% fields.each do |field_name, field| %>
           <div class="row">
             <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>">
-              <%= render_document_show_field_label document, field: field_name %></dt>
+              <%= find_item_field_label(document, field_name) %></dt>
             <dd class="blacklight-<%= field_name.parameterize %> <%= add_class_dd %>">
-              <%= doc_presenter.field_value field unless field_name == "id" %>
-              <%= link_to purl(doc_presenter.field_value(field)), purl(doc_presenter.field_value(field)) if field_name == "id" %>
+              <%= find_item_field_value(doc_presenter, field, field_name) %>
             </dd>
           </div>
         <% end %>

--- a/app/views/catalog/_is_part_of_block.html.erb
+++ b/app/views/catalog/_is_part_of_block.html.erb
@@ -16,17 +16,19 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms(:is_part_of) %>
 <% if fields.length > 0 %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <dl>
+      <dl title="<%= title %>">
         <% if document['member_of_collection_ids_ssim'].present? %>
             <% col_link = document["member_of_collection_ids_ssim"].first %>
             <% col_title = document["member_of_collections_ssim"]&.first %>
+            <dt title="parent collection link"></dt>
             <dd class="blacklight-member_of_collections"><a href=<%= col_link %>><%= col_title || "Parent Collection" %></a></dd>
         <% end %>
         <% if document['parent_work_for_lux_tesim'].present? %>
           <% link, link_title = document['parent_work_for_lux_tesim'].first.split(', ') %>
+          <dt title="parent work link"></dt>
           <dd class='blacklight-parent_member_of_collections'><a href=<%= link %>><%= link_title %></a></dd>
         <% end %>
       </dl>

--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -1,10 +1,10 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms %>
 <% if fields.length > 0 %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= title %>">
     <div class="card-header rounded-0"><%= title %></div>
     <div class="card-body">
-      <dl>
+      <dl title="<%= title %>">
         <% fields.each do |field_name, field| %>
           <div class="row">
             <dt class="blacklight-<%= field_name.parameterize %> <%= add_class_dt %>">

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,10 +1,10 @@
 <% if show_doc_actions? %>
-  <div class="card mb-2 rounded-0">
+  <div class="card mb-2 rounded-0" title="<%= t('blacklight.tools.title') %>">
     <div class="card-header rounded-0">
       <%= t('blacklight.tools.title') %>
     </div>
 
-    <ul class="list-group list-group-flush">
+    <ul class="list-group list-group-flush" title="<%= t('blacklight.tools.title') %> Links">
       <%= render_show_doc_actions @document do |config, inner| %>
         <li class="list-group-item <%= config.key %>">
           <%= inner %>

--- a/app/views/catalog/_this_item_contains_block.html.erb
+++ b/app/views/catalog/_this_item_contains_block.html.erb
@@ -1,7 +1,7 @@
 <% child_works = presenter.new(document: document).children %>
 <% if child_works %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
-    <div class="card-header rounded-0">This item contains:</div>
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= t('blacklight.work.this_item_contains') %>">
+    <div class="card-header rounded-0"><%= t('blacklight.work.this_item_contains') %></div>
     <div class="card-body">
       <% child_works.each do |w| %>
         <dl class="row">

--- a/app/views/catalog/_view_items_in_collection_block.html.erb
+++ b/app/views/catalog/_view_items_in_collection_block.html.erb
@@ -1,9 +1,10 @@
 <% doc_presenter = show_presenter(document) %>
 <% fields = presenter.new(document: doc_presenter.fields_to_render).terms(:view_items_in_this_collection) %>
-  <div class="<%= presenter_class %> card mb-2 rounded-0">
+  <div class="<%= presenter_class %> card mb-2 rounded-0" title="<%= t('blacklight.work.view_items_collection') %>">
     <div class="card-body">
-      <dl>
-        <dd class="blacklight-view-items-in-collection"><a href="/?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= CGI::escape(document[:title_tesim]&.first) %>&per_page=10">View items in this digital collection</a></dd>
+      <dl title="<%= t('blacklight.work.view_items_collection') %>">
+        <dt title="collection link"></dt>
+        <dd class="blacklight-view-items-in-collection"><a href="/?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= CGI::escape(document[:title_tesim]&.first) %>&per_page=10"><%= t('blacklight.work.view_items_collection') %></a></dd>
       </dl>
     </div>
   </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -45,6 +45,8 @@ en:
       about_this_item:
         downloads: 'Downloads are not permitted for this material.'
         low_resolution: 'This item is provided at low resolution only.'
+      view_items_collection: 'View items in this digital collection'
+      this_item_contains: 'This item contains:'
 
   static:
     not_found:

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -209,4 +209,14 @@ RSpec.describe "View a Work", type: :system, js: false do
   it 'has a linked rights statement' do
     expect(page).to have_link('In Copyright - Non-Commercial Use Permitted', href: 'http://rightsstatements.org/vocab/InC-NC/1.0/')
   end
+
+  context 'accessibility html' do
+    context 'dls' do
+      it 'each have a title attribute' do
+        page_dls = page.find_all('dl')
+
+        expect(page_dls.map { |d| d['title'] }.compact.size).to eq(page_dls.size)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- app/helpers/*: refactors away some of the logic in the partials.
- _about_this_collection_block.html.erb and _metadata_block.html.erb: adds title element into wrapping `div` and `dl`.
- _about_this_item_block.html.erb and _find_this_item_block.html.erb: ditto above and refactors logic into helper.
- app/views/catalog/_access_and_copyright_block.html.erb: ditto two above, but also adds title to copyright disclaimer.
- app/views/catalog/_is_part_of_block.html.erb: ditto three above and inserts recommended `dt`s that describe the `dd` below. (see https://www.w3.org/TR/WCAG20-TECHS/H40.html)
- _show_tools.html.erb and _this_item_contains_block.html.erb: uses localization for the titles.
- app/views/catalog/_view_items_in_collection_block.html.erb: same as above and inserts a `dt` for descriptiveness.
- config/locales/blacklight.en.yml: creates new localizations.
- spec/*: checks coverage.