### PR TITLE
Adjust metadata blocks for mobile

### DIFF
--- a/app/views/catalog/_metadata_all.html.erb
+++ b/app/views/catalog/_metadata_all.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row d-none d-lg-flex">
   <div class="col-md-3">
     <%= render "metadata_col_1", document: document %>
   </div>
@@ -7,5 +7,21 @@
   </div>
   <div class="col-md-3">
     <%= render "metadata_col_3", document: document %>
+  </div>
+</div>
+<div class="row d-lg-none">
+  <div class="col">
+    <%= render 'is_part_of_block', document: document, presenter: MetadataPresenter, presenter_class: 'is-part-of', title: 'This item is part of:' %>
+    <% if document["has_model_ssim"]&.first == "Collection" %>
+      <%= render 'about_this_collection_block', document: document, presenter: MetadataPresenter, presenter_class: 'about-this-collection', title: 'About This Collection' %>
+      <% title_for_find_col = 'Find This Collection' %>
+    <% end %>
+    <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
+      <%= render 'about_this_item_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
+    <% end %>
+    <%= render "show_tools", document: document %>
+    <%= render 'metadata_block', document: document, presenter: SubjectsKeywordsPresenter, presenter_class: 'subjects-keywords', title: 'Subjects / Keywords', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
+    <%= render 'find_this_item_block', document: document, presenter: MetadataPresenter, presenter_class: 'find-this-item', title: "#{title_for_find_col || 'Find This Item'}", add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
+    <%= render 'access_and_copyright_block', document: document, presenter: MetadataPresenter, presenter_class: 'access-and-copyright', title: 'Access and Copyright' %>
   </div>
 </div>

--- a/app/views/catalog/_metadata_all.html.erb
+++ b/app/views/catalog/_metadata_all.html.erb
@@ -11,17 +11,6 @@
 </div>
 <div class="row d-lg-none">
   <div class="col">
-    <%= render 'is_part_of_block', document: document, presenter: MetadataPresenter, presenter_class: 'is-part-of', title: 'This item is part of:' %>
-    <% if document["has_model_ssim"]&.first == "Collection" %>
-      <%= render 'about_this_collection_block', document: document, presenter: MetadataPresenter, presenter_class: 'about-this-collection', title: 'About This Collection' %>
-      <% title_for_find_col = 'Find This Collection' %>
-    <% end %>
-    <% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
-      <%= render 'about_this_item_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
-    <% end %>
-    <%= render "show_tools", document: document %>
-    <%= render 'metadata_block', document: document, presenter: SubjectsKeywordsPresenter, presenter_class: 'subjects-keywords', title: 'Subjects / Keywords', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
-    <%= render 'find_this_item_block', document: document, presenter: MetadataPresenter, presenter_class: 'find-this-item', title: "#{title_for_find_col || 'Find This Item'}", add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
-    <%= render 'access_and_copyright_block', document: document, presenter: MetadataPresenter, presenter_class: 'access-and-copyright', title: 'Access and Copyright' %>
+    <%= render 'metadata_mobile', document: document %>
   </div>
 </div>

--- a/app/views/catalog/_metadata_mobile.html.erb
+++ b/app/views/catalog/_metadata_mobile.html.erb
@@ -1,0 +1,12 @@
+<%= render 'is_part_of_block', document: document, presenter: MetadataPresenter, presenter_class: 'is-part-of', title: 'This item is part of:' %>
+<% if document["has_model_ssim"]&.first == "Collection" %>
+  <%= render 'about_this_collection_block', document: document, presenter: MetadataPresenter, presenter_class: 'about-this-collection', title: 'About This Collection' %>
+  <% title_for_find_col = 'Find This Collection' %>
+<% end %>
+<% if document["has_model_ssim"]&.first == "CurateGenericWork" %>
+  <%= render 'about_this_item_block', document: document, presenter: AboutThisItemPresenter, presenter_class: 'about-this-item', title: 'About This Item', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
+<% end %>
+<%= render "show_tools", document: document %>
+<%= render 'metadata_block', document: document, presenter: SubjectsKeywordsPresenter, presenter_class: 'subjects-keywords', title: 'Subjects / Keywords', add_class_dt: "col-md-5", add_class_dd: "col-md-7" %>
+<%= render 'find_this_item_block', document: document, presenter: MetadataPresenter, presenter_class: 'find-this-item', title: "#{title_for_find_col || 'Find This Item'}", add_class_dt: "col-md-12", add_class_dd: "col-md-12" %>
+<%= render 'access_and_copyright_block', document: document, presenter: MetadataPresenter, presenter_class: 'access-and-copyright', title: 'Access and Copyright' %>

--- a/spec/system/work_citation_spec.rb
+++ b/spec/system/work_citation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "View a Work Citation", type: :system, js: false do
     solr.commit
     allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
     visit solr_document_path(id)
-    click_link('citationLink')
+    first("#citationLink").click
   end
 
   let(:id) { "030prr4xkj-cor" }


### PR DESCRIPTION
- Changes the order and presence of metadata blocks in mobile view

**Sample object in desktop view:**
<img width="1259" alt="Screen Shot 2020-07-24 at 3 02 21 PM" src="https://user-images.githubusercontent.com/46227821/88426247-dc328480-cdbe-11ea-9408-248391af19ce.png">
**Sample object in mobile view with reordered metadata blocks:**
<img width="283" alt="Screen Shot 2020-07-24 at 3 02 37 PM" src="https://user-images.githubusercontent.com/46227821/88426255-e05ea200-cdbe-11ea-970e-92dcc7146017.png">
