### PR TITLE
Switches variable environment to the catalog controller (#191).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -11,6 +11,8 @@ class CatalogController < ApplicationController
     visibility = visibility_lookup(resource_id_param)
     case visibility
     when 'emory_low', 'authenticated'
+      Rails.logger.debug "CatalogController#render_404: request.url: #{request.url}"
+      session[:requested_page] = request.url
       redirect_to new_user_session_path
     when 'rose_high', 'restricted'
       render file: Rails.root.join('app', 'views', 'static', 'reading_room_not_found.html.erb'), status: :not_found, layout: true

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -3,8 +3,6 @@ class OmniauthController < Devise::SessionsController
   def new
     # Rails.logger.debug "SessionsController#new: request.referer = #{request.referer}"
     if Rails.env.production?
-      Rails.logger.debug "OmniauthController#new: request.url: #{request.url}"
-      session[:requested_page] = request.url
       redirect_to user_shibboleth_omniauth_authorize_path
     else
       super


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: inserts session variable into catalog controller, where it can be verified locally.
- app/controllers/omniauth_controller.rb: removes the variable here, since it only sees the sign-in url.