### PR TITLE
Header breaks when pressing back from Advanced Search page (#673).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'simple_form'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1241,9 +1241,6 @@ GEM
       nokogiri (~> 1.9)
       slop (>= 3.4.5, < 4.0)
       yell
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -1331,7 +1328,6 @@ DEPENDENCIES
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery3
 //= require rails-ujs
-//= require turbolinks
 //
 // Required by Blacklight
 //= require popper

--- a/app/assets/javascripts/explore_collections.js
+++ b/app/assets/javascripts/explore_collections.js
@@ -1,3 +1,8 @@
+$(document).ready( function() {
+  setExploreCollectionsHeight()
+  $(window).on('resize', setExploreCollectionsHeight)
+})
+
 function setExploreCollectionsHeight() {
   if (desktopWidth(window)) {
     matchFacetsHeight()

--- a/app/assets/javascripts/explore_collections.js
+++ b/app/assets/javascripts/explore_collections.js
@@ -1,8 +1,3 @@
-$(document).on('turbolinks:load', function() {
-  setExploreCollectionsHeight()
-  $(window).on('resize', setExploreCollectionsHeight)
-})
-
 function setExploreCollectionsHeight() {
   if (desktopWidth(window)) {
     matchFacetsHeight()

--- a/app/assets/javascripts/fielded_search_dropdown.js
+++ b/app/assets/javascripts/fielded_search_dropdown.js
@@ -1,6 +1,0 @@
-// Retrigger the fielded search dropdown after navigating the site
-// through turbolinks
-
-$(document).on('ready turbolinks:load', function() {
-  $(window).trigger('load.bs.select.data-api');
-});

--- a/app/assets/javascripts/hero_image.js
+++ b/app/assets/javascripts/hero_image.js
@@ -1,5 +1,0 @@
-// Retrigger the hero image carousel after navigating the site
-// through turbolinks
-$(document).on('turbolinks:load', function() {
-  $('.carousel').carousel();
-});

--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,7 +1,0 @@
-$(document).on('turbolinks:load', function() {
-  $('.universal-viewer-iframe').width($('.uv-container').width())
-
-  $(window).on('resize', function(){
-    $('.universal-viewer-iframe').width($('.uv-container').width())
-  })
-})

--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,0 +1,7 @@
+$(document).ready( function() {
+  $('.universal-viewer-iframe').width($('.uv-container').width())
+
+  $(window).on('resize', function(){
+    $('.universal-viewer-iframe').width($('.uv-container').width())
+  })
+})

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only sr-only-focusable"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
-  <div id="search-fields" class="input-group col-md-12" data-turbolinks-permanent>
+  <div id="search-fields" class="input-group col-md-12">
     <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
                        options_for_select(search_fields, h(params[:search_field])),

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for(:skip_links) do -%>
-    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3' %>
 <% end %>
 
 <% content_for(:container_header) do -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Cardo:400,700|Open+Sans:400,700&display=swap" type='text/css' >
 
     <%= csrf_meta_tags %>
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -30,8 +30,8 @@
 
 
       <div id="skip-link">
-      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3' %>
+      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'sr-only sr-only-focusable rounded-bottom py-2 px-3' %>
       <%= content_for(:skip_links) %>
     </div>
     <%= render partial: 'shared/header_navbar' %>


### PR DESCRIPTION
- Gemfile*: removes the Turbolinks Gem.
- app/assets/javascripts/application.js: extracts Turbolinks Javascript.
- uv_width.js and explore_collections.js: changes focus to overall document ready state.
- hero_image.js and fielded_search_dropdown.js: removes unneeded Turbolinks re-triggering.
- _search_form.html.erb, _search_results.html.erb, and base.html.erb: omits calls to turbolink controls.
- app/views/layouts/application.html.erb: takes out the requirement of TL JS and CSS.