### PR TITLE
Adjusts the Explore Our Collections link to only find Source Collections (#684).

### DIFF
--- a/app/views/catalog/_explore_collections.html.erb
+++ b/app/views/catalog/_explore_collections.html.erb
@@ -1,7 +1,7 @@
 <% presenter = ExploreCollectionsPresenter.new %>
 <% collections = presenter.collections %>
 <div class="homepage-content-header">
-  <h2 class="homepage-content-heading explore-collections-heading"><%= link_to 'Explore Our Collections', search_action_path('f[has_model_ssim][]' => 'Collection'), class: "browse-link" %></h2>
+  <h2 class="homepage-content-heading explore-collections-heading"><%= link_to 'Explore Our Collections', search_action_path('f[has_model_ssim][]' => 'Collection', 'f[visibility_ssi][]' => 'open'), class: "browse-link" %></h2>
 </div>
 <div class="tiles row justify-content-between">
   <% collections.each do |c| %>

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'front page', type: :system do
   end
 
   it 'has Explore Our Collections hyperlink', js: true do
-    expect(page).to have_link('Explore Our Collections')
+    explore_path = find('a.browse-link', text: "Explore Our Collections")['href']
+
+    expect(explore_path).to include('has_model_ssim', 'Collection', 'visibility_ssi', 'open')
   end
 end


### PR DESCRIPTION
- app/views/catalog/_explore_collections.html.erb: adds the requirement that visibility is open.
- spec/system/front_page_spec.rb: checks that link exists and has the right query limiters.