### PR TITLE
Omits the </span> tag that shows in facet modal pagination (#685).

### DIFF
--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,0 +1,21 @@
+<!-- This is a Blacklight 7.4.3 overwrite that is required to remove a string of "</span>" occuring after the disabled "Previous" links
+     in the pagination bar -->
+<div class="prev_next_links btn-group float-md-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
+  <% end %>
+</div>
+
+<div class="sort-options btn-group float-md-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
+    <span class="active numeric btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,0 +1,24 @@
+<!-- This is a Blacklight 7.4.3 overwrite that is required to properly align the two pagination bars (top and bottom) together -->
+<div class="facet-pagination top">
+  <%= render :partial=>'facet_pagination' %>
+</div>
+
+<div class="modal-header">
+  <h1 class="modal-title"><%= facet_field_label(@facet.key) %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<div class="modal-body">
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
+  <div class="facet-extended-list">
+  <%= render_facet_limit(@display_facet, layout: false) %>
+  </div>
+</div>
+
+<div class="modal-footer"></div>
+<div class="facet-pagination bottom">
+  <%= render :partial=>'facet_pagination' %>
+</div>


### PR DESCRIPTION
- app/views/catalog/_facet_pagination.html.erb: swaps out plain html span call to a content_tag erb helper used in later versions of Blacklight.
- app/views/catalog/facet.html.erb: alters the layout of the bottom rendering of the facet pagination bar so that it aligns the same as the top.