### PR TITLE
Adjusts the View Items element to look at Source Collection Title (#693).

### DIFF
--- a/app/views/catalog/_view_items_in_collection_block.html.erb
+++ b/app/views/catalog/_view_items_in_collection_block.html.erb
@@ -4,7 +4,7 @@
     <div class="card-body">
       <dl title="<%= t('blacklight.work.view_items_collection') %>">
         <dt title="collection link"></dt>
-        <dd class="blacklight-view-items-in-collection"><a href="/?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= CGI::escape(document[:title_tesim]&.first) %>&per_page=10"><%= t('blacklight.work.view_items_collection') %></a></dd>
+        <dd class="blacklight-view-items-in-collection"><a href="/?f%5Bsource_collection_title_ssim%5D%5B%5D=<%= CGI::escape(document[:title_tesim]&.first) %>&per_page=10"><%= t('blacklight.work.view_items_collection') %></a></dd>
       </dl>
     </div>
   </div>

--- a/spec/system/view_collection_spec.rb
+++ b/spec/system/view_collection_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "View a Collection", type: :system, js: false do
 
   it 'has Collection specific metadata labels' do
     expect(page).to have_content('View items in this digital collection')
-    expect(page).to have_link('View items in this digital collection', href: "#{root_path}?f%5Bmember_of_collections_ssim%5D%5B%5D=#{CGI.escape(work_attributes[:title_tesim]&.first)}&per_page=10")
+    expect(page).to have_link('View items in this digital collection', href: "#{root_path}?f%5Bsource_collection_title_ssim%5D%5B%5D=#{CGI.escape(work_attributes[:title_tesim]&.first)}&per_page=10")
   end
 
   it 'has Collection specific metadata values' do


### PR DESCRIPTION
- app/views/catalog/_view_items_in_collection_block.html.erb: swaps `member_of_collections_ssim` for `source_collection_title_ssim`.
- spec/system/view_collection_spec.rb: changes link expectation.