### PR TITLE
Adds full-text searching to Lux sites.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,7 +21,7 @@
 //= require blacklight/blacklight
 
 //= require bootstrap-select
-
+//= require newspaper_works/ocr_search
 //= require_tree .
 
 

--- a/app/assets/javascripts/newspaper_works/ocr_search.js.erb
+++ b/app/assets/javascripts/newspaper_works/ocr_search.js.erb
@@ -1,0 +1,14 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+
+/* toggle the ocr snippets collapse link text */
+$(document).ready(function(){
+  $('.ocr_snippets_expand').click(function() {
+    $(this).text($(this).text() == '<%= I18n.t('blacklight.search.results.snippets.more') %>' ? '<%= I18n.t('blacklight.search.results.snippets.less') %>' : '<%= I18n.t('blacklight.search.results.snippets.more') %>');
+  });
+});

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -1,0 +1,18 @@
+// gem 'newspaper_works', v1.0.2
+// Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+// Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+// This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+// This gem is used for keyword highlighting in search results
+
+$highlight-background-color: rgba(5,166,86,0.36);
+
+#search-results .thumbnail_highlight, #documents .thumbnail_highlight {
+  background-color: $highlight-background-color;
+  z-index: 1000;
+  position: absolute;
+}
+
+.metadata em {
+  background-color: $highlight-background-color;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -6,13 +6,13 @@
 
 $highlight-background-color: rgba(5,166,86,0.36);
 
-#search-results .thumbnail_highlight, #documents .thumbnail_highlight {
-  background-color: $highlight-background-color;
-  z-index: 1000;
-  position: absolute;
-}
+// #search-results .thumbnail_highlight, #documents .thumbnail_highlight {
+//   background-color: $highlight-background-color;
+//   z-index: 1000;
+//   position: absolute;
+// }
 
-.metadata em {
+.ocr_snippet em {
   background-color: $highlight-background-color;
   font-weight: bold;
 }

--- a/app/assets/stylesheets/lux.scss
+++ b/app/assets/stylesheets/lux.scss
@@ -35,3 +35,4 @@
 @import 'lux/hero_image';
 @import 'bootstrap';
 @import 'bootstrap-select';
+@import 'search_results';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,7 +50,7 @@ class CatalogController < ApplicationController
     ## Should the raw solr document endpoint (e.g. /catalog/:id/raw) be enabled
     # config.raw_endpoint.enabled = false
 
-    list_of_common_fields =<<-EOS.gsub(/^[\s\t]*/, '').gsub(/[\s\t]*\n/, ' ').strip
+    list_of_common_fields = <<-EOS.gsub(/^[\s\t]*/, '').gsub(/[\s\t]*\n/, ' ').strip
       system_of_record_ID_tesim primary_repository_ID_tesim emory_ark_tesim local_call_number_tesim
       other_identifiers_tesim title_tesim uniform_title_tesim series_title_tesim parent_title_tesim
       creator_tesim contributors_tesim keywords_tesim subject_topics_tesim subject_names_tesim

--- a/app/helpers/additional_catalog_helper.rb
+++ b/app/helpers/additional_catalog_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module AdditionalCatalogHelper
+  include NewspaperWorks::NewspaperWorksHelperBehavior
+
   def purl(doc_id)
     "https://digital.library.emory.edu/purl/#{doc_id}"
   end

--- a/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
+++ b/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+
+module NewspaperWorks
+  module NewspaperWorksHelperBehavior
+    ##
+    # print the ocr snippets. if more than one, separate with <br/>
+    #
+    # @param options [Hash] options hash provided by Blacklight
+    # @return [String] snippets HTML to be rendered
+    # rubocop:disable Rails/OutputSafety
+    def render_ocr_snippets(options = {})
+      snippets = options[:value]
+      snippets_content = [tag.div("... #{snippets.first} ...".html_safe,
+                                      class: 'ocr_snippet first_snippet')]
+      if snippets.length > 1
+        snippets_content << render(partial: 'catalog/snippets_more',
+                                   locals:  { snippets: snippets.drop(1),
+                                              options:  options })
+      end
+      snippets_content.join("\n").html_safe
+    end
+    # rubocop:enable Rails/OutputSafety
+  end
+end

--- a/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
+++ b/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
@@ -19,8 +19,10 @@ module NewspaperWorks
                                       class: 'ocr_snippet first_snippet')]
       if snippets.length > 1
         snippets_content << render(partial: 'catalog/snippets_more',
-                                   locals:  { snippets: snippets.drop(1),
-                                              options:  options })
+                                   locals: {
+                                     snippets: snippets.drop(1),
+                                     options: options
+                                   })
       end
       snippets_content.join("\n").html_safe
     end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
+require './lib/newspaper_works/highlight_search_params.rb'
+
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
-
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
-  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  include NewspaperWorks::HighlightSearchParams
+
+  self.default_processor_chain += [
+    :add_advanced_parse_q_to_solr, :add_advanced_search_to_solr, :highlight_search_params
+  ]
 
   ##
   # @example Adding a new step to the processor chain

--- a/app/views/catalog/_snippets_more.html.erb
+++ b/app/views/catalog/_snippets_more.html.erb
@@ -1,0 +1,23 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+<%# additional ocr snippets, with a Bootstrap collapse toggle control %>
+<% document_id = options[:document].id %>
+<div class="collapse ocr_snippet" id="<%= "snippet_collapse_#{document_id}" %>">
+  <% snippets.each do |snippet| %>
+    <%= content_tag('div',
+                    "... #{snippet} ...".html_safe,
+                    class: 'ocr_snippet') %>
+  <% end %>
+</div>
+<%= link_to(t('blacklight.search.results.snippets.more'),
+            "#snippet_collapse_#{document_id}",
+            data: {toggle: 'collapse'},
+            'aria-expanded' => 'false',
+            'aria-controls' => "#snippet_collapse_#{document_id}",
+            class: 'ocr_snippets_expand js-controls')
+%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -36,9 +36,15 @@ en:
     search:
       facets:
         title: 'Browse All Items'
+      fields:
+        all_text_tsimv: 'Full-text matches'
       form:
         search:
           placeholder: 'Search Digital Collections'
+      results:
+        snippets:
+          less: '<< less'
+          more: 'more >>'
     search_history:
       recent: 'Your recent searches (cleared after your browser session)'
     work:

--- a/lib/newspaper_works/highlight_search_params.rb
+++ b/lib/newspaper_works/highlight_search_params.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+
+module NewspaperWorks
+  # add highlighting on _stored_ full text field if this is a keyword search
+  # can be added to default_processor_chain in a SearchBuilder class
+  module HighlightSearchParams
+    # add highlights on full text field, if there is a keyword query
+    def highlight_search_params(solr_parameters = {})
+      return unless solr_parameters[:q] || solr_parameters[:all_fields]
+      solr_parameters[:hl] = true
+      solr_parameters[:'hl.fl'] = 'all_text_tsimv'
+      solr_parameters[:'hl.fragsize'] = 100
+      solr_parameters[:'hl.snippets'] = 5
+    end
+  end
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe CatalogController, type: :controller do
        'holding_repository_tesim',
        'human_readable_content_type',
        'human_readable_date_created_tesim',
-       'visibility_group_ssi']
+       'visibility_group_ssi',
+       'all_text_tsimv']
     end
     it { expect(index_fields).to contain_exactly(*expected_index_fields) }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 require 'simplecov'
+require 'webdrivers/chromedriver'
+
+Webdrivers::Chromedriver.required_version = "114.0.5735.90" unless ENV['CI']
+
 SimpleCov.start 'rails' do
   add_filter '/spec/' # for rspec
   add_filter '/app/jobs/'

--- a/spec/support/solr_documents/curate_generic_work.rb
+++ b/spec/support/solr_documents/curate_generic_work.rb
@@ -81,5 +81,6 @@ CURATE_GENERIC_WORK = {
   thumbnail_path_ss: ['/downloads/825x69p8dh-cor?file=thumbnail'],
   hasRelatedImage_ssim: ['825x69p8dh-cor'],
   human_readable_visibility_ssi: 'Public',
-  visibility_group_ssi: 'Public'
+  visibility_group_ssi: 'Public',
+  all_text_tsimv: ["This is the story of Teddy Longfellow, who lived to a hundred and three!"]
 }.freeze

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "View Search Results", type: :system, js: false do
     solr.commit
     ENV['THUMBNAIL_URL'] = 'http://obviously_fake_url.com'
   end
+  after { delete_all_documents_from_solr }
 
   let(:collection_id) { COLLECTION[:id] }
   let(:parent_work_id) { PARENT_CURATE_GENERIC_WORK[:id] }
@@ -84,6 +85,21 @@ RSpec.feature "View Search Results", type: :system, js: false do
       click_on('search')
 
       expect(page).to have_css('dl.document-heading-second-row')
+    end
+  end
+
+  context 'when searching for a work indexed for full-text searching' do
+    it 'returns only the simple work with the expected elements' do
+      visit "/"
+      fill_in 'q', with: 'teddy longfellow'
+      click_on('search')
+
+      expect(find_all('#documents article header h3 a').size).to eq(1)
+      expect(page).to have_content('The Title of my Work')
+      expect(page).to have_content('Full-text matches:')
+      expect(page).to have_content(
+        '... This is the story of Teddy Longfellow, who lived to a hundred and three! ...'
+      )
     end
   end
 end


### PR DESCRIPTION
- app/assets/*, app/helpers/newspaper_works/newspaper_works_helper_behavior.rb, app/models/search_builder.rb, app/views/catalog/_snippets_more.html.erb, lib/newspaper_works/highlight_search_params.rb: imports code from the curate implementation.
- app/controllers/catalog_controller.rb: adds `all_text_tsimv ` field to search results and search options.
- app/helpers/additional_catalog_helper.rb: includes imported method into appropriate module.
- config/locales/blacklight.en.yml: imports localization from curate code, but changes the label verbiage per request.
- spec/*: updates expectations.
- spec/spec_helper.rb: sidesteps new webdriver Chrome behavior locally.